### PR TITLE
Fix: Capitrack face with error when 'npm install -g capitrack' #8

### DIFF
--- a/bin/capitrack.js
+++ b/bin/capitrack.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const fs = require("fs");
+
+// Set default titles/info
+process.title = "capitrack";
+
+// Ensure we are running from the dist directory or can find it
+const serverPath = path.join(__dirname, "../dist/server.js");
+
+if (!fs.existsSync(serverPath)) {
+  console.error(
+    'Error: Capitrack server not found. Please run "npm run build" first.',
+  );
+  process.exit(1);
+}
+
+// Check for DB_PATH, if not set, suggest or set a default in user's home directory
+if (!process.env.DB_PATH) {
+  const homeDir =
+    process.env.HOME || process.env.USERPROFILE || process.env.HOMEPATH;
+  if (homeDir) {
+    const defaultDbDir = path.join(homeDir, ".capitrack");
+    if (!fs.existsSync(defaultDbDir)) {
+      fs.mkdirSync(defaultDbDir, { recursive: true });
+    }
+    process.env.DB_PATH = path.join(defaultDbDir, "capitrack.db");
+    console.log(`Using default database at: ${process.env.DB_PATH}`);
+  }
+}
+
+// Start the server
+require(serverPath);

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "capitrack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Capitrack - Personal wealth tracking and investment portfolio management platform",
   "main": "dist/server.js",
+  "bin": {
+    "capitrack": "bin/capitrack.js"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/server.js",
@@ -34,22 +37,22 @@
   "homepage": "https://github.com/jeff-nasseri/Capitrack#readme",
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "better-sqlite3": "^11.7.0",
+    "better-sqlite3": "^12.6.2",
     "better-sqlite3-session-store": "^0.1.0",
     "csv-parse": "^5.5.3",
     "csv-stringify": "^6.4.5",
     "express": "^4.21.0",
     "express-session": "^1.18.1",
-    "multer": "^1.4.5-lts.1",
+    "multer": "^2.0.2",
     "yahoo-finance2": "^3.13.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
-    "@types/better-sqlite3": "^7.6.11",
+    "@types/better-sqlite3": "^11.7.0",
     "@types/express": "^4.17.21",
     "@types/express-session": "^1.18.0",
     "@types/jest": "^29.5.12",
-    "@types/multer": "^1.4.11",
+    "@types/multer": "^2.0.0",
     "@types/node": "^20.11.24",
     "jest": "^30.2.0",
     "rimraf": "^5.0.5",
@@ -64,6 +67,7 @@
   },
   "files": [
     "dist",
-    "src/public"
+    "src/public",
+    "bin"
   ]
 }


### PR DESCRIPTION
I have fixed the installation and execution issues for Capitrack on Windows. The primary cause of the error was the better-sqlite3 package failing to build from source because it couldn't find a Visual Studio installation with the required C++ workload. This occurred because prebuilt binaries were missing for the newer Node.js version being used (v24.x).

# Key Changes:
**Resolved Build Failure:** Upgraded better-sqlite3 from v11.7.0 to v12.6.2, which includes prebuilt binaries for newer Node.js versions (Node 24 and above), avoiding the need for native compilation during installation.

**Addressed Security Warnings:** Updated multer to v2.0.2 to resolve the deprecated vulnerabilities warned by npm.

**Enabled Global CLI Mode:** Added a CLI wrapper script in bin/capitrack.jsand registered it in package.json. This allows users to run Capitrack globally using the capitrack command after installation with npm install -g capitrack.

**Improved Data Persistence:** The new CLI wrapper automatically sets a default database path in the user's home directory (~/.capitrack/capitrack.db) if DB_PATH is not specified. This ensures that a global installation doesn't attempt to write data intoprotected system directories.

**Updated Package Metadata:** Bumped the version to 1.0.1 and ensured the new bin directory is included in the published package.