### PR TITLE
feat: savings/cash accounts, bulk + Check & Import, crypto staking flag

### DIFF
--- a/src/client/Client.Application/Models/MarketDataProviderDto.cs
+++ b/src/client/Client.Application/Models/MarketDataProviderDto.cs
@@ -1,0 +1,29 @@
+namespace Client.Application.Models;
+
+/// <summary>A market-data provider Capitrack can source live prices from (e.g. Yahoo Finance).</summary>
+public class MarketDataProviderDto
+{
+    /// <summary>Stable identifier (e.g. "yahoo-finance").</summary>
+    public string Id { get; set; } = "";
+
+    /// <summary>Human-friendly provider name.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>Short description of what the provider offers.</summary>
+    public string Description { get; set; } = "";
+
+    /// <summary>Whether the provider is currently active.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Whether the provider needs an API key to be configured.</summary>
+    public bool RequiresApiKey { get; set; }
+
+    /// <summary>Whether an API key has already been supplied for this provider.</summary>
+    public bool ApiKeySet { get; set; }
+
+    /// <summary>The provider's public website.</summary>
+    public string Website { get; set; } = "";
+
+    /// <summary>Whether this is the default provider used for price lookups.</summary>
+    public bool IsDefault { get; set; }
+}

--- a/src/client/Client.Application/Models/PreviewFileDto.cs
+++ b/src/client/Client.Application/Models/PreviewFileDto.cs
@@ -1,0 +1,9 @@
+namespace Client.Application.Models;
+
+/// <summary>One uploaded file's parsed preview during a "Check &amp; Import" flow (file name, detected format and the parsed rows).</summary>
+public class PreviewFileDto
+{
+    public string FileName { get; set; } = "";
+    public string Format { get; set; } = "";
+    public List<PreviewTransactionDto> Transactions { get; set; } = [];
+}

--- a/src/client/Client.Application/Models/PreviewTransactionDto.cs
+++ b/src/client/Client.Application/Models/PreviewTransactionDto.cs
@@ -1,10 +1,9 @@
 namespace Client.Application.Models;
 
-/// <summary>A single buy/sell/transfer/dividend transaction within an account.</summary>
-public class TransactionDto
+/// <summary>A single parsed-but-not-yet-imported transaction row shown in the "Check &amp; Import" preview.</summary>
+public class PreviewTransactionDto
 {
-    public int Id { get; set; }
-    public int AccountId { get; set; }
+    public int Index { get; set; }
     public string Symbol { get; set; } = "";
     public string Type { get; set; } = "buy";
     public double Quantity { get; set; }
@@ -13,8 +12,6 @@ public class TransactionDto
     public string Currency { get; set; } = "EUR";
     public string Date { get; set; } = "";
     public string Notes { get; set; } = "";
-    public bool IsStaked { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public string? AccountName { get; set; }
-    public List<TagDto> Tags { get; set; } = [];
+    public bool IsDuplicate { get; set; }
+    public bool CanStake { get; set; }
 }

--- a/src/client/Client.Application/Models/SelectedTransactionDto.cs
+++ b/src/client/Client.Application/Models/SelectedTransactionDto.cs
@@ -1,10 +1,8 @@
 namespace Client.Application.Models;
 
-/// <summary>A single buy/sell/transfer/dividend transaction within an account.</summary>
-public class TransactionDto
+/// <summary>A transaction the user chose to import from the "Check &amp; Import" preview (sent to /import/selected).</summary>
+public class SelectedTransactionDto
 {
-    public int Id { get; set; }
-    public int AccountId { get; set; }
     public string Symbol { get; set; } = "";
     public string Type { get; set; } = "buy";
     public double Quantity { get; set; }
@@ -14,7 +12,4 @@ public class TransactionDto
     public string Date { get; set; } = "";
     public string Notes { get; set; } = "";
     public bool IsStaked { get; set; }
-    public DateTime CreatedAt { get; set; }
-    public string? AccountName { get; set; }
-    public List<TagDto> Tags { get; set; } = [];
 }

--- a/src/client/Client.Application/Models/TransactionFormModel.cs
+++ b/src/client/Client.Application/Models/TransactionFormModel.cs
@@ -12,5 +12,6 @@ public class TransactionFormModel
     public double Fee { get; set; }
     public string Currency { get; set; } = "EUR";
     public string Notes { get; set; } = "";
+    public bool IsStaked { get; set; }
     public HashSet<int> TagIds { get; set; } = [];
 }

--- a/src/client/Client.Infrastructure/Components/AccountForm.razor
+++ b/src/client/Client.Infrastructure/Components/AccountForm.razor
@@ -12,6 +12,10 @@
         </div>
         <div class="field"><label>Currency</label><input class="input" type="text" @bind="Model.Currency" maxlength="5" /></div>
     </div>
+    @if (Model.Type is "savings")
+    {
+        <p class="sub" style="margin-top:-6px;">Plain cash in one currency — no symbols or market prices.</p>
+    }
     <div class="form-row">
         <div class="field">
             <label>Icon</label>

--- a/src/client/Client.Infrastructure/Components/CheckImportModal.razor
+++ b/src/client/Client.Infrastructure/Components/CheckImportModal.razor
@@ -1,0 +1,227 @@
+@namespace Client.Infrastructure.Components
+@implements IDisposable
+@inject ModalService Modal
+@inject ApiClient Api
+@inject AppState State
+@inject ToastService Toast
+
+@if (Modal.CheckImportVisible)
+{
+    <div class="modal-overlay" @onclick="Close">
+        <div class="modal" style="max-width:820px;width:94vw;" @onclick:stopPropagation="true">
+            <div class="modal-header">
+                <h3>Check &amp; Import</h3>
+                <button class="btn-icon" @onclick="Close"><Icon Name="x" /></button>
+            </div>
+            <div class="modal-body" style="max-height:80vh;overflow:auto;">
+                @if (_loading)
+                {
+                    <div class="loading-spinner">Parsing file(s)…</div>
+                }
+                else if (_result is not null)
+                {
+                    <div class="success-message"><strong>Import complete.</strong> @($"Imported {_result.Imported} · Skipped {_result.Skipped} · Total {_result.Total}")</div>
+                    <button class="btn btn-pri btn-block mt-4" @onclick="Close">Done</button>
+                }
+                else if (_files.Count == 0)
+                {
+                    <div class="empty-state"><Icon Name="info" /><p>No transactions were found in the selected file(s).</p></div>
+                }
+                else
+                {
+                    @* one tab per file *@
+                    @if (_files.Count > 1)
+                    {
+                        <div class="flex gap-1" style="border-bottom:1px solid var(--border);margin-bottom:12px;flex-wrap:wrap;">
+                            @for (var i = 0; i < _files.Count; i++)
+                            {
+                                var idx = i;
+                                var f = _files[idx];
+                                <button class="btn btn-sm @(_activeTab == idx ? "btn-pri" : "btn-ghost")" @onclick="() => _activeTab = idx">
+                                    @ShortName(f.FileName) <span style="opacity:0.75;">(@f.Rows.Count(r => r.Selected)/@f.Rows.Count)</span>
+                                </button>
+                            }
+                        </div>
+                    }
+
+                    var active = _files[Math.Min(_activeTab, _files.Count - 1)];
+                    <div class="flex row-between" style="margin-bottom:10px;align-items:center;flex-wrap:wrap;gap:8px;">
+                        <span class="chip pri">@FormatName(active.Format)</span>
+                        <label class="flex gap-2" style="align-items:center;font-size:0.85rem;cursor:pointer;">
+                            <input type="checkbox" checked="@active.Rows.All(r => r.Selected)" @onchange="e => ToggleAll(active, (bool)(e.Value ?? false))" />
+                            <span class="sub">Select all · @active.Rows.Count(r => r.Selected)/@active.Rows.Count</span>
+                        </label>
+                    </div>
+
+                    <div style="overflow-x:auto;">
+                        <table class="tbl" style="width:100%;font-size:0.84rem;">
+                            <thead>
+                                <tr>
+                                    <th style="width:30px;"></th>
+                                    <th>Date</th><th>Type</th><th>Symbol</th>
+                                    <th class="r">Qty</th><th class="r">Price</th><th>Flags</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var row in active.Rows)
+                                {
+                                    <tr style="@(row.Tx.IsDuplicate ? "opacity:0.55;" : "")">
+                                        <td><input type="checkbox" checked="@row.Selected" @onchange="e => row.Selected = (bool)(e.Value ?? false)" /></td>
+                                        <td style="white-space:nowrap;">@row.Tx.Date</td>
+                                        <td><TxnBadge Type="@row.Tx.Type" /></td>
+                                        <td class="num">@row.Tx.Symbol</td>
+                                        <td class="r num">@Format.Shares(row.Tx.Quantity)</td>
+                                        <td class="r num">@Format.Money(row.Tx.Price, row.Tx.Currency)</td>
+                                        <td>
+                                            <div class="flex gap-2" style="align-items:center;">
+                                                @if (row.Tx.CanStake)
+                                                {
+                                                    <label class="flex gap-1" style="align-items:center;cursor:pointer;" title="Count as staked (still part of wealth even though sent out)">
+                                                        <input type="checkbox" checked="@row.Staked" @onchange="e => row.Staked = (bool)(e.Value ?? false)" />
+                                                        <span class="sub">stake</span>
+                                                    </label>
+                                                }
+                                                @if (row.Tx.IsDuplicate)
+                                                {
+                                                    <span class="chip" style="font-size:0.68rem;color:var(--text-3);">duplicate</span>
+                                                }
+                                            </div>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="flex gap-2 mt-4" style="justify-content:flex-end;align-items:center;">
+                        <span class="sub" style="margin-right:auto;">@SelectedCount selected across @_files.Count file@(_files.Count == 1 ? "" : "s")</span>
+                        <button class="btn btn-ghost btn-sm" @onclick="Close">Cancel</button>
+                        <button class="btn btn-pri btn-sm" @onclick="DoImport" disabled="@(_busy || SelectedCount == 0)">
+                            <Icon Name="upload" /> @(_busy ? "Importing…" : $"Import {SelectedCount} selected")
+                        </button>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private bool _loading;
+    private bool _busy;
+    private int _activeTab;
+    private ImportResultDto? _result;
+    private List<FileVM> _files = [];
+    private IReadOnlyList<IBrowserFile>? _loadedFor;
+
+    private int SelectedCount => _files.Sum(f => f.Rows.Count(r => r.Selected));
+
+    private sealed class FileVM
+    {
+        public string FileName = "";
+        public string Format = "";
+        public List<RowVM> Rows = [];
+    }
+
+    private sealed class RowVM
+    {
+        public required PreviewTransactionDto Tx;
+        public bool Selected;
+        public bool Staked;
+    }
+
+    protected override void OnInitialized() => Modal.OnChange += OnModalChange;
+
+    private void OnModalChange() => InvokeAsync(async () =>
+    {
+        if (Modal.CheckImportVisible && !ReferenceEquals(_loadedFor, Modal.CheckImportFiles))
+        {
+            _loadedFor = Modal.CheckImportFiles;
+            await LoadPreview();
+        }
+        else if (!Modal.CheckImportVisible && _loadedFor is not null)
+        {
+            Reset();
+        }
+        StateHasChanged();
+    });
+
+    private async Task LoadPreview()
+    {
+        _loading = true; _result = null; _activeTab = 0; _files = [];
+        StateHasChanged();
+        try
+        {
+            var files = Modal.CheckImportFiles;
+            if (files is null || files.Count == 0 || State.CurrentAccountId is null) return;
+
+            using var content = new MultipartFormDataContent();
+            foreach (var f in files)
+                content.Add(new StreamContent(f.OpenReadStream(15 * 1024 * 1024)), "files", f.Name);
+            content.Add(new StringContent(State.CurrentAccountId.Value.ToString()), "account_id");
+
+            var preview = await Api.PostFormAsync<List<PreviewFileDto>>("/api/transactions/import/preview", content) ?? [];
+            _files = preview.Select(p => new FileVM
+            {
+                FileName = p.FileName,
+                Format = p.Format,
+                Rows = p.Transactions.Select(t => new RowVM { Tx = t, Selected = !t.IsDuplicate, Staked = false }).ToList()
+            }).ToList();
+        }
+        catch { Toast.Show("Could not parse the selected file(s)", "error"); }
+        finally { _loading = false; StateHasChanged(); }
+    }
+
+    private static void ToggleAll(FileVM f, bool on)
+    {
+        foreach (var r in f.Rows) r.Selected = on;
+    }
+
+    private async Task DoImport()
+    {
+        if (State.CurrentAccountId is null || SelectedCount == 0) return;
+        _busy = true;
+        try
+        {
+            var selected = _files.SelectMany(f => f.Rows).Where(r => r.Selected).Select(r => new SelectedTransactionDto
+            {
+                Symbol = r.Tx.Symbol, Type = r.Tx.Type, Quantity = r.Tx.Quantity, Price = r.Tx.Price,
+                Fee = r.Tx.Fee, Currency = r.Tx.Currency, Date = r.Tx.Date, Notes = r.Tx.Notes, IsStaked = r.Staked
+            }).ToList();
+
+            var body = new { account_id = State.CurrentAccountId.Value, transactions = selected };
+            _result = await Api.PostAsync<ImportResultDto>("/api/transactions/import/selected", body);
+            if (_result is not null && _result.Error is null)
+            {
+                Modal.RaiseImported();
+                Toast.Show($"Imported {_result.Imported} transaction(s)", "success");
+            }
+        }
+        catch { Toast.Show("Import failed", "error"); }
+        finally { _busy = false; StateHasChanged(); }
+    }
+
+    private void Reset()
+    {
+        _files = []; _result = null; _activeTab = 0; _loadedFor = null; _loading = false; _busy = false;
+    }
+
+    private void Close()
+    {
+        Reset();
+        Modal.CloseCheckImport();
+    }
+
+    private static string ShortName(string name) => name.Length > 24 ? name[..22] + "…" : name;
+
+    private static string FormatName(string fmt) => fmt switch
+    {
+        "revolut-stocks" => "Revolut Stocks",
+        "revolut-commodities" => "Revolut Commodities",
+        "trezor" => "Trezor",
+        "generic" => "Generic CSV",
+        _ => "Unknown format"
+    };
+
+    public void Dispose() => Modal.OnChange -= OnModalChange;
+}

--- a/src/client/Client.Infrastructure/Components/ConfirmDialog.razor
+++ b/src/client/Client.Infrastructure/Components/ConfirmDialog.razor
@@ -1,0 +1,39 @@
+@namespace Client.Infrastructure.Components
+@implements IDisposable
+@inject ConfirmService Confirm
+
+@if (Confirm.Current is { } req)
+{
+    var accent = req.Danger ? "var(--down)" : "var(--pri-2)";
+    var accentSoft = req.Danger ? "var(--down-soft)" : "var(--pri-soft)";
+    var iconName = req.Icon ?? (req.Danger ? "trash" : "info");
+
+    <div class="modal-overlay" style="z-index:300;" @onclick="Cancel">
+        <div class="modal" style="max-width:440px;" @onclick:stopPropagation="true">
+            <div class="modal-body" style="padding:24px;">
+                <div class="flex gap-3" style="align-items:flex-start;">
+                    <div style="@($"flex-shrink:0;width:42px;height:42px;border-radius:12px;display:flex;align-items:center;justify-content:center;background:{accentSoft};color:{accent};")">
+                        <Icon Name="@iconName" Width="20" Height="20" />
+                    </div>
+                    <div style="flex:1;min-width:0;">
+                        <h3 style="font-size:1.05rem;font-weight:750;letter-spacing:-0.01em;margin-bottom:6px;">@req.Title</h3>
+                        <p class="sub" style="white-space:pre-line;line-height:1.5;">@req.Message</p>
+                    </div>
+                </div>
+                <div class="flex gap-2" style="justify-content:flex-end;margin-top:24px;">
+                    <button class="btn btn-ghost btn-sm" @onclick="Cancel">@req.CancelText</button>
+                    <button class="btn btn-sm @(req.Danger ? "btn-danger" : "btn-pri")" @onclick="Ok" autofocus>@req.ConfirmText</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private void Ok() => Confirm.Resolve(true);
+    private void Cancel() => Confirm.Resolve(false);
+
+    protected override void OnInitialized() => Confirm.OnChange += Refresh;
+    private void Refresh() => InvokeAsync(StateHasChanged);
+    public void Dispose() => Confirm.OnChange -= Refresh;
+}

--- a/src/client/Client.Infrastructure/Components/ImportModal.razor
+++ b/src/client/Client.Infrastructure/Components/ImportModal.razor
@@ -15,21 +15,27 @@
             <div class="modal-body">
                 <p class="sub" style="line-height:1.6;margin-bottom:14px;">
                     <strong style="color:var(--text-2);">Supported formats:</strong> Revolut Stocks, Revolut Commodities, Trezor, or generic CSV.
-                    The format is auto-detected and duplicate rows are skipped.
+                    Select one or more files — the format is auto-detected and duplicate rows are skipped.
                 </p>
                 <div class="field">
-                    <label>CSV file</label>
-                    <InputFile OnChange="OnFileSelected" accept=".csv" class="input" style="padding:9px 13px;height:auto;" />
+                    <label>CSV file(s)</label>
+                    <InputFile OnChange="OnFilesSelected" accept=".csv" multiple class="input" style="padding:9px 13px;height:auto;" />
                 </div>
-                @if (_formatName is not null)
+                @if (_files.Count > 0)
                 {
                     <div class="mt-2" style="margin-bottom:14px;">
-                        <span class="chip @(_isKnown ? "up" : "warn")"><Icon Name="@(_isKnown ? "check" : "info")" Width="13" Height="13" /> @_formatName</span>
+                        <span class="chip up"><Icon Name="check" Width="13" Height="13" /> @_files.Count file@(_files.Count == 1 ? "" : "s") selected</span>
                     </div>
                 }
-                <button class="btn btn-pri btn-block mt-2" @onclick="DoImport" disabled="@(_file is null || _busy)">
-                    <Icon Name="upload" /> Import
-                </button>
+                <div class="flex gap-2 mt-2">
+                    <button class="btn btn-pri" style="flex:1;" @onclick="DoImport" disabled="@(_files.Count == 0 || _busy)">
+                        <Icon Name="upload" /> @(_busy ? "Importing…" : "Import all")
+                    </button>
+                    <button class="btn btn-ghost" style="flex:1;" @onclick="DoCheckImport" disabled="@(_files.Count == 0 || _busy)">
+                        <Icon Name="filter" /> Check &amp; Import
+                    </button>
+                </div>
+                <p class="sub mt-2" style="font-size:0.78rem;">“Import all” adds every row; “Check &amp; Import” lets you pick rows and flag staking first.</p>
                 @if (_result is not null)
                 {
                     <div class="@(_result.Error is null ? "success-message" : "error-message")" style="margin-top:14px;">
@@ -49,60 +55,48 @@
 }
 
 @code {
-    private IBrowserFile? _file;
-    private string? _formatName;
-    private bool _isKnown;
+    private List<IBrowserFile> _files = [];
     private ImportResultDto? _result;
     private bool _busy;
-
-    private static readonly Dictionary<string, string> FormatNames = new()
-    {
-        ["revolut-stocks"] = "Revolut Stocks",
-        ["revolut-commodities"] = "Revolut Commodities",
-        ["trezor"] = "Trezor Wallet",
-        ["generic"] = "Generic CSV",
-        ["unknown"] = "Unknown format"
-    };
 
     protected override void OnInitialized() => Modal.OnChange += Refresh;
     private void Refresh() => InvokeAsync(StateHasChanged);
 
     private void Close()
     {
-        _file = null; _formatName = null; _result = null;
+        _files = []; _result = null;
         Modal.CloseImport();
     }
 
-    private async Task OnFileSelected(InputFileChangeEventArgs e)
+    private void OnFilesSelected(InputFileChangeEventArgs e)
     {
-        _file = e.File;
+        _files = e.GetMultipleFiles(20).ToList();
         _result = null;
-        try
-        {
-            using var content = new MultipartFormDataContent();
-            content.Add(new StreamContent(_file.OpenReadStream(10 * 1024 * 1024)), "file", _file.Name);
-            var detect = await Api.PostFormAsync<DetectResultDto>("/api/transactions/import/detect", content);
-            var fmt = detect?.Format ?? "unknown";
-            _isKnown = fmt != "unknown";
-            _formatName = FormatNames.GetValueOrDefault(fmt, fmt);
-        }
-        catch { _formatName = null; }
     }
 
     private async Task DoImport()
     {
-        if (_file is null || State.CurrentAccountId is null) return;
+        if (_files.Count == 0 || State.CurrentAccountId is null) return;
         _busy = true;
         try
         {
             using var content = new MultipartFormDataContent();
-            content.Add(new StreamContent(_file.OpenReadStream(10 * 1024 * 1024)), "file", _file.Name);
+            foreach (var f in _files)
+                content.Add(new StreamContent(f.OpenReadStream(15 * 1024 * 1024)), "files", f.Name);
             content.Add(new StringContent(State.CurrentAccountId.Value.ToString()), "account_id");
-            _result = await Api.PostFormAsync<ImportResultDto>("/api/transactions/import/csv", content);
+            _result = await Api.PostFormAsync<ImportResultDto>("/api/transactions/import/csv/bulk", content);
             if (_result is not null && _result.Error is null) Modal.RaiseImported();
         }
         catch { Toast.Show("Import failed", "error"); }
         finally { _busy = false; }
+    }
+
+    private void DoCheckImport()
+    {
+        if (_files.Count == 0) return;
+        var files = _files;
+        Modal.CloseImport();
+        Modal.ShowCheckImport(files);
     }
 
     public void Dispose() => Modal.OnChange -= Refresh;

--- a/src/client/Client.Infrastructure/Components/TransactionForm.razor
+++ b/src/client/Client.Infrastructure/Components/TransactionForm.razor
@@ -32,6 +32,10 @@
         </div>
     </div>
     <div class="field"><label>Notes</label><input class="input" type="text" @bind="Model.Notes" /></div>
+    <label class="tag-checkbox" style="align-self:flex-start;">
+        <input type="checkbox" checked="@Model.IsStaked" @onchange="e => Model.IsStaked = (bool)(e.Value ?? false)" />
+        <span>Staked (counts toward wealth even though sent out)</span>
+    </label>
     @if (Tags.Count > 0)
     {
         <div class="field">

--- a/src/client/Client.Infrastructure/Services/ApiClient.cs
+++ b/src/client/Client.Infrastructure/Services/ApiClient.cs
@@ -39,6 +39,26 @@ public class ApiClient(HttpClient http) : IApiClient
         return await r.Content.ReadFromJsonAsync<T>(Json);
     }
 
+    /// <summary>
+    /// GETs a payload together with the total row count advertised by the
+    /// <c>X-Total-Count</c> response header (used for server-side pagination).
+    /// Returns a zero count when the header is absent.
+    /// </summary>
+    public async Task<(T? value, int total)> GetWithCountAsync<T>(string url)
+    {
+        var r = await http.GetAsync(url);
+        if (!Check(r, url)) return (default, 0);
+        var value = await r.Content.ReadFromJsonAsync<T>(Json);
+
+        var total = 0;
+        if ((r.Headers.TryGetValues("X-Total-Count", out var values) ||
+             r.Content.Headers.TryGetValues("X-Total-Count", out values)) &&
+            int.TryParse(values.FirstOrDefault(), out var parsed))
+            total = parsed;
+
+        return (value, total);
+    }
+
     public async Task<T?> PostAsync<T>(string url, object body, JsonSerializerOptions? opts = null)
     {
         var r = await http.PostAsJsonAsync(url, body, opts ?? Json);
@@ -81,5 +101,14 @@ public class ApiClient(HttpClient http) : IApiClient
         var r = await http.PostAsync(url, content);
         if (r.StatusCode == HttpStatusCode.Unauthorized) { Unauthorized?.Invoke(); return default; }
         return await r.Content.ReadFromJsonAsync<T>(Json);
+    }
+
+    /// <summary>Multipart POST that also reports whether the request succeeded (for upload flows that surface errors).</summary>
+    public async Task<(bool ok, T? value)> PostFormWithStatusAsync<T>(string url, MultipartFormDataContent content)
+    {
+        var r = await http.PostAsync(url, content);
+        if (r.StatusCode == HttpStatusCode.Unauthorized && !url.Contains("/auth/")) Unauthorized?.Invoke();
+        var value = await r.Content.ReadFromJsonAsync<T>(Json);
+        return (r.IsSuccessStatusCode, value);
     }
 }

--- a/src/client/Client.Infrastructure/Services/ConfirmRequest.cs
+++ b/src/client/Client.Infrastructure/Services/ConfirmRequest.cs
@@ -1,0 +1,26 @@
+namespace Client.Infrastructure.Services;
+
+/// <summary>
+/// Describes a single confirmation prompt rendered by the in-app
+/// <c>ConfirmDialog</c>, replacing the browser's native <c>window.confirm</c>.
+/// </summary>
+public sealed class ConfirmRequest
+{
+    /// <summary>Short, bold dialog heading (e.g. "Delete account").</summary>
+    public required string Title { get; init; }
+
+    /// <summary>Explanatory body text. Newlines are honoured (rendered pre-line).</summary>
+    public required string Message { get; init; }
+
+    /// <summary>Label of the affirmative button.</summary>
+    public string ConfirmText { get; init; } = "Confirm";
+
+    /// <summary>Label of the dismissive button.</summary>
+    public string CancelText { get; init; } = "Cancel";
+
+    /// <summary>When true the dialog uses the destructive (red) styling and icon.</summary>
+    public bool Danger { get; init; }
+
+    /// <summary>Optional icon name override; defaults to a danger/info icon based on <see cref="Danger"/>.</summary>
+    public string? Icon { get; init; }
+}

--- a/src/client/Client.Infrastructure/Services/ConfirmService.cs
+++ b/src/client/Client.Infrastructure/Services/ConfirmService.cs
@@ -1,0 +1,45 @@
+namespace Client.Infrastructure.Services;
+
+/// <summary>
+/// Drives the application's confirmation dialog. Awaitable: callers do
+/// <c>if (await Confirm.AskAsync(...)) { ... }</c> instead of the browser's
+/// blocking <c>window.confirm</c>, so confirmations get the app's own UI/UX.
+/// A single dialog is shown at a time; a new request supersedes any pending one.
+/// </summary>
+public sealed class ConfirmService
+{
+    private TaskCompletionSource<bool>? _pending;
+
+    /// <summary>The request currently being shown, or null when the dialog is closed.</summary>
+    public ConfirmRequest? Current { get; private set; }
+
+    /// <summary>Raised whenever the dialog opens or closes so the host can re-render.</summary>
+    public event Action? OnChange;
+
+    /// <summary>Shows the dialog and completes when the user confirms (true) or cancels (false).</summary>
+    public Task<bool> AskAsync(ConfirmRequest request)
+    {
+        // Resolve any previously-pending request as cancelled before replacing it.
+        _pending?.TrySetResult(false);
+
+        Current = request;
+        _pending = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        OnChange?.Invoke();
+        return _pending.Task;
+    }
+
+    /// <summary>Convenience overload for the common "danger delete" case.</summary>
+    public Task<bool> AskAsync(string title, string message, string confirmText = "Confirm", bool danger = false, string? icon = null) =>
+        AskAsync(new ConfirmRequest { Title = title, Message = message, ConfirmText = confirmText, Danger = danger, Icon = icon });
+
+    /// <summary>Closes the dialog and resolves the awaiting caller with the user's choice.</summary>
+    public void Resolve(bool result)
+    {
+        if (_pending is null) return;
+        Current = null;
+        OnChange?.Invoke();
+        var pending = _pending;
+        _pending = null;
+        pending.TrySetResult(result);
+    }
+}

--- a/src/client/Client.Infrastructure/Services/ModalService.cs
+++ b/src/client/Client.Infrastructure/Services/ModalService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 
 namespace Client.Infrastructure.Services;
 
@@ -10,6 +11,10 @@ public class ModalService
     public bool IsOpen => Body != null;
 
     public bool ImportVisible { get; private set; }
+
+    /// <summary>The files chosen for a "Check &amp; Import" preview, or null when the check modal is closed.</summary>
+    public IReadOnlyList<IBrowserFile>? CheckImportFiles { get; private set; }
+    public bool CheckImportVisible => CheckImportFiles != null;
 
     public event Action? OnChange;
     public event Action? OnImported;
@@ -38,6 +43,19 @@ public class ModalService
     public void CloseImport()
     {
         ImportVisible = false;
+        OnChange?.Invoke();
+    }
+
+    /// <summary>Opens the "Check &amp; Import" modal to preview the given file(s) before importing.</summary>
+    public void ShowCheckImport(IReadOnlyList<IBrowserFile> files)
+    {
+        CheckImportFiles = files;
+        OnChange?.Invoke();
+    }
+
+    public void CloseCheckImport()
+    {
+        CheckImportFiles = null;
         OnChange?.Invoke();
     }
 }

--- a/src/client/Client.Presentation/Layout/MainLayout.razor
+++ b/src/client/Client.Presentation/Layout/MainLayout.razor
@@ -14,3 +14,4 @@
 <ModalHost />
 <ImportModal />
 <ToastHost />
+<ConfirmDialog />

--- a/src/client/Client.Presentation/Layout/MainLayout.razor
+++ b/src/client/Client.Presentation/Layout/MainLayout.razor
@@ -13,5 +13,6 @@
 
 <ModalHost />
 <ImportModal />
+<CheckImportModal />
 <ToastHost />
 <ConfirmDialog />

--- a/src/client/Client.Presentation/Pages/AccountDetail.razor
+++ b/src/client/Client.Presentation/Pages/AccountDetail.razor
@@ -8,36 +8,103 @@
 @inject NavigationManager Nav
 @inject IJSRuntime JS
 
+@{
+    var isCash = _account?.Type is "savings" or "cash";
+}
+
 <div class="page page-wide">
     @* hero *@
     <div class="row-between" style="align-items:flex-start;">
         <div>
             <div class="eyebrow">@(_account?.Type) account</div>
-            <div class="bignum tnum" style="margin-top:6px;">@Format.Money(_totalValue, _base)</div>
-            <div class="flex gap-2 mt-2">
-                <span class="chip @(_gain >= 0 ? "up" : "down")">@Format.Signed(_gain, _base) · @Format.Pct(_gainPct)</span>
-                <span class="sub">all time</span>
-            </div>
+            @if (isCash)
+            {
+                <div class="bignum tnum" style="margin-top:6px;">@Format.Money(_cashBalance, _account?.Currency)</div>
+                <div class="flex gap-2 mt-2">
+                    <span class="chip pri">Cash balance</span>
+                    <span class="sub">@_account?.Currency</span>
+                </div>
+            }
+            else
+            {
+                <div class="bignum tnum" style="margin-top:6px;">@Format.Money(_totalValue, _base)</div>
+                <div class="flex gap-2 mt-2">
+                    <span class="chip @(_gain >= 0 ? "up" : "down")">@Format.Signed(_gain, _base) · @Format.Pct(_gainPct)</span>
+                    <span class="sub">all time</span>
+                </div>
+            }
         </div>
     </div>
 
     @* chart *@
     <div class="card mt-4" style="overflow:hidden;">
         <div style="padding:16px 12px;">
-            <PeriodChart Data="_chart" Labels="_labels" Currency="@_base" Height="230" Selected="@_period" SelectedChanged="OnPeriod" />
+            @if (isCash)
+            {
+                <AreaChart Data="_cashChart" Labels="_cashLabels" Currency="@_account?.Currency" Height="230" />
+            }
+            else
+            {
+                <PeriodChart Data="_chart" Labels="_labels" Currency="@_base" Height="230" Selected="@_period" SelectedChanged="OnPeriod" />
+            }
         </div>
     </div>
 
     @* KPI strip *@
-    <div class="grid mt-4" style="grid-template-columns:repeat(4, 1fr);">
-        <StatCard Label="Investments" Value="@Format.Money(_invested, _base)" />
-        <StatCard Label="Net contribution" Value="@Format.Money(_contribution, _base)" />
-        <StatCard Label="Cost basis" Value="@Format.Money(_totalCost, _base)" />
-        <StatCard Label="Cash balance" Value="@Format.Money(0, _base)" />
-    </div>
+    @if (isCash)
+    {
+        <div class="grid mt-4" style="grid-template-columns:repeat(3, 1fr);">
+            <StatCard Label="Balance" Value="@Format.Money(_cashBalance, _account?.Currency)" />
+            <StatCard Label="Total in" Value="@Format.Money(_cashIn, _account?.Currency)" />
+            <StatCard Label="Total out" Value="@Format.Money(_cashOut, _account?.Currency)" />
+        </div>
 
-    <div class="section-title mt-6" style="margin-bottom:12px;">Holdings</div>
-    <HoldingsTable Holdings="_holdings" AccountId="Id" />
+        <div class="section-title mt-6" style="margin-bottom:12px;">Cash movements</div>
+        <div class="card" style="overflow:hidden;">
+            <div style="overflow-x:auto;">
+                <table class="tbl">
+                    <thead>
+                        <tr>
+                            <th style="padding-top:16px;">Date</th>
+                            <th style="padding-top:16px;">Movement</th>
+                            <th class="r" style="padding-top:16px;">Amount</th>
+                            <th style="padding-top:16px;">Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if (_cashMovements.Count == 0)
+                        {
+                            <tr><td colspan="4" class="sub" style="text-align:center;padding:28px;">No cash movements yet.</td></tr>
+                        }
+                        @foreach (var tx in _cashMovements)
+                        {
+                            var isIn = tx.Type is "transfer_in" or "buy";
+                            <tr>
+                                <td style="white-space:nowrap;">@Format.Date(tx.Date)</td>
+                                <td><span class="chip @(isIn ? "up" : "warn")">@(isIn ? "Deposit" : "Withdrawal")</span></td>
+                                <td class="r num" style="font-weight:650;color:@(isIn ? "var(--up)" : "var(--down)");">
+                                    @(isIn ? "+" : "−")@Format.Money(tx.Quantity * tx.Price, _account?.Currency)
+                                </td>
+                                <td class="sub">@tx.Notes</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="grid mt-4" style="grid-template-columns:repeat(4, 1fr);">
+            <StatCard Label="Investments" Value="@Format.Money(_invested, _base)" />
+            <StatCard Label="Net contribution" Value="@Format.Money(_contribution, _base)" />
+            <StatCard Label="Cost basis" Value="@Format.Money(_totalCost, _base)" />
+            <StatCard Label="Cash balance" Value="@Format.Money(0, _base)" />
+        </div>
+
+        <div class="section-title mt-6" style="margin-bottom:12px;">Holdings</div>
+        <HoldingsTable Holdings="_holdings" AccountId="Id" />
+    }
 </div>
 
 @code {
@@ -53,10 +120,25 @@
     private double _totalValue, _totalCost, _invested, _contribution, _gain, _gainPct;
     private List<TagDto> _tags = [];
 
+    // Cash-account state (computed client-side; no Yahoo / history calls).
+    private bool IsCash => _account?.Type is "savings" or "cash";
+    private List<TransactionDto> _cashMovements = [];
+    private List<double> _cashChart = [];
+    private List<string> _cashLabels = [];
+    private double _cashBalance, _cashIn, _cashOut;
+    private readonly CashFormModel _cash = new();
+
     private RenderFragment Actions => @<text>
         <button class="btn-icon" title="Import" @onclick="() => Modal.ShowImport()"><Icon Name="upload" /></button>
         <button class="btn-icon" title="Export" @onclick="Export"><Icon Name="download" /></button>
-        <button class="btn btn-pri btn-sm" @onclick="ShowAddTx"><Icon Name="plus" /> Transaction</button>
+        @if (IsCash)
+        {
+            <button class="btn btn-pri btn-sm" @onclick="ShowAddCash"><Icon Name="plus" /> Add cash</button>
+        }
+        else
+        {
+            <button class="btn btn-pri btn-sm" @onclick="ShowAddTx"><Icon Name="plus" /> Transaction</button>
+        }
     </text>;
 
     protected override void OnInitialized() => Modal.OnImported += OnImported;
@@ -87,6 +169,13 @@
         _base = (await sessionTask)?.BaseCurrency ?? _account.Currency;
 
         TopBar.Set(_account.Name, Actions, onBack: () => Nav.NavigateTo("/accounts"));
+
+        if (IsCash)
+        {
+            BuildCash();
+            StateHasChanged();
+            return;
+        }
 
         var symbols = holdings.Select(h => h.Symbol).ToList();
         var prices = symbols.Count > 0 ? await Api.PostAsync<Dictionary<string, QuoteDto>>("/api/prices/quotes", new { symbols }) ?? [] : [];
@@ -127,6 +216,40 @@
         await LoadChart(_period);
     }
 
+    // Builds the cash balance, totals, movement list and running-balance chart entirely client-side
+    // from the account's transactions (deposits = transfer_in/buy, withdrawals = transfer_out/sell).
+    private void BuildCash()
+    {
+        static double Signed(TransactionDto t) =>
+            t.Type is "transfer_in" or "buy" ? t.Quantity * t.Price
+            : t.Type is "transfer_out" or "sell" ? -(t.Quantity * t.Price)
+            : 0;
+
+        _cashMovements = _transactions
+            .OrderByDescending(t => t.Date)
+            .ThenByDescending(t => t.Id)
+            .ToList();
+
+        _cashIn = _transactions.Where(t => t.Type is "transfer_in" or "buy").Sum(t => t.Quantity * t.Price);
+        _cashOut = _transactions.Where(t => t.Type is "transfer_out" or "sell").Sum(t => t.Quantity * t.Price);
+        _cashBalance = _cashIn - _cashOut;
+
+        var chrono = _transactions.OrderBy(t => t.Date).ThenBy(t => t.Id).ToList();
+        var running = 0d;
+        _cashChart = [];
+        _cashLabels = [];
+        var dates = new List<string>();
+        foreach (var t in chrono)
+        {
+            running += Signed(t);
+            _cashChart.Add(running);
+            dates.Add(t.Date);
+        }
+        // The area chart needs at least two points to render a line.
+        if (_cashChart.Count == 1) { _cashChart.Insert(0, 0); dates.Insert(0, chrono[0].Date); }
+        _cashLabels = BuildLabels(dates);
+    }
+
     private async Task LoadChart(string period)
     {
         _period = period;
@@ -152,10 +275,55 @@
         await Api.PostAsync<TransactionDto>("/api/transactions", new
         {
             account_id = Id, symbol = m.Symbol, type = m.Type, date = m.Date, quantity = m.Quantity ?? 0,
-            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, tag_ids = m.TagIds.ToList()
+            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, is_staked = m.IsStaked, tag_ids = m.TagIds.ToList()
         });
         Modal.Close();
         Toast.Show("Transaction added", "success");
+        await Reload();
+    }
+
+    private void ShowAddCash()
+    {
+        _cash.Reset(_account?.Currency ?? "EUR");
+        Modal.Show("Add cash", CashFormFragment);
+    }
+
+    private RenderFragment CashFormFragment => @<form @onsubmit="SaveCash" @onsubmit:preventDefault>
+        <div class="form-row">
+            <div class="field"><label>Amount</label><input class="input" type="number" step="any" min="0" @bind="_cash.Amount" required /></div>
+            <div class="field">
+                <label>Direction</label>
+                <select class="input" @bind="_cash.Direction">
+                    <option value="Deposit">Deposit</option>
+                    <option value="Withdrawal">Withdrawal</option>
+                </select>
+            </div>
+        </div>
+        <div class="field">
+            <label>Date</label>
+            <input class="input" type="date" value="@_cash.Date" @onchange="e => _cash.Date = e.Value?.ToString() ?? string.Empty" required />
+        </div>
+        <div class="field"><label>Notes</label><input class="input" type="text" @bind="_cash.Notes" /></div>
+        <button type="submit" class="btn btn-pri btn-block"><Icon Name="check" /> Save</button>
+    </form>;
+
+    private async Task SaveCash()
+    {
+        var currency = _account?.Currency ?? "EUR";
+        await Api.PostAsync<TransactionDto>("/api/transactions", new
+        {
+            account_id = Id,
+            symbol = currency,
+            type = _cash.Direction == "Deposit" ? "transfer_in" : "transfer_out",
+            quantity = _cash.Amount ?? 0,
+            price = 1,
+            fee = 0,
+            currency,
+            date = _cash.Date,
+            notes = _cash.Notes
+        });
+        Modal.Close();
+        Toast.Show("Cash movement added", "success");
         await Reload();
     }
 
@@ -175,4 +343,21 @@
     }
 
     public void Dispose() => Modal.OnImported -= OnImported;
+
+    // Small model backing the inline "Add cash" form.
+    private sealed class CashFormModel
+    {
+        public double? Amount { get; set; }
+        public string Direction { get; set; } = "Deposit";
+        public string Date { get; set; } = DateTime.UtcNow.ToString("yyyy-MM-dd");
+        public string Notes { get; set; } = "";
+
+        public void Reset(string currency)
+        {
+            Amount = null;
+            Direction = "Deposit";
+            Date = DateTime.UtcNow.ToString("yyyy-MM-dd");
+            Notes = "";
+        }
+    }
 }

--- a/src/client/Client.Presentation/Pages/Activity.razor
+++ b/src/client/Client.Presentation/Pages/Activity.razor
@@ -2,6 +2,7 @@
 @inject ApiClient Api
 @inject ModalService Modal
 @inject ToastService Toast
+@inject ConfirmService Confirm
 @inject TopBarState TopBar
 @inject IJSRuntime JS
 
@@ -25,16 +26,59 @@
             <option value="dividend">Dividend</option>
             <option value="transfer_in">Transfer in</option>
         </select>
-        <span class="sub" style="margin-left:auto;align-self:center;">@_filtered.Count transactions</span>
+        <select class="input btn-sm" style="height:36px;width:auto;padding-right:28px;" value="@_pageSize" @onchange="OnPageSize">
+            <option value="25">25 / page</option>
+            <option value="50">50 / page</option>
+            <option value="100">100 / page</option>
+        </select>
+        <span class="sub" style="margin-left:auto;align-self:center;">@_total transaction@(_total == 1 ? "" : "s")</span>
     </div>
 
     @if (_loading)
     {
         <div class="loading-spinner">Loading…</div>
     }
+    else if (_transactions.Count == 0)
+    {
+        <div class="empty-state"><Icon Name="receipt" /><p>No transactions match these filters.</p></div>
+    }
     else
     {
-        <ActivityTable Transactions="_filtered" OnEdit="EditTx" OnDelete="DeleteTx" />
+        <ActivityTable Transactions="_transactions" OnEdit="EditTx" OnDelete="DeleteTx" />
+
+        @if (_totalPages > 1)
+        {
+            <div class="flex gap-2" style="justify-content:center;align-items:center;margin-top:18px;flex-wrap:wrap;">
+                <button class="btn btn-ghost btn-sm" disabled="@(_page <= 1)" @onclick="() => GoTo(_page - 1)">Prev</button>
+
+                @if (PageWindow().First() > 1)
+                {
+                    <button class="btn btn-ghost btn-sm" style="min-width:34px;" @onclick="() => GoTo(1)">1</button>
+                    @if (PageWindow().First() > 2)
+                    {
+                        <span class="sub" style="padding:0 2px;">…</span>
+                    }
+                }
+
+                @foreach (var p in PageWindow())
+                {
+                    var current = p;
+                    <button class="btn btn-sm @(current == _page ? "btn-pri" : "btn-ghost")" style="min-width:34px;" @onclick="() => GoTo(current)">@current</button>
+                }
+
+                @if (PageWindow().Last() < _totalPages)
+                {
+                    @if (PageWindow().Last() < _totalPages - 1)
+                    {
+                        <span class="sub" style="padding:0 2px;">…</span>
+                    }
+                    <button class="btn btn-ghost btn-sm" style="min-width:34px;" @onclick="() => GoTo(_totalPages)">@_totalPages</button>
+                }
+
+                <button class="btn btn-ghost btn-sm" disabled="@(_page >= _totalPages)" @onclick="() => GoTo(_page + 1)">Next</button>
+            </div>
+            <p class="sub" style="text-align:center;margin-top:8px;">Showing @_rangeStart–@_rangeEnd of @_total</p>
+        }
     }
 </div>
 
@@ -43,20 +87,34 @@
     private List<AccountDto> _accounts = [];
     private List<TagDto> _tags = [];
     private bool _loading = true;
+
     private string _search = "";
     private string _acct = "All";
     private string _type = "All";
 
-    private List<TransactionDto> _filtered =>
-        _transactions.Where(t =>
-            (_acct == "All" || t.AccountName == _acct) &&
-            (_type == "All" || t.Type == _type) &&
-            (_search == "" || (t.Symbol ?? "").Contains(_search, StringComparison.OrdinalIgnoreCase)))
-        .ToList();
+    private int _page = 1;
+    private int _pageSize = 25;
+    private int _total;
+
+    private CancellationTokenSource _searchDebounce = new();
+
+    private int _totalPages => Math.Max(1, (int)Math.Ceiling(_total / (double)_pageSize));
+    private int _rangeStart => _total == 0 ? 0 : (_page - 1) * _pageSize + 1;
+    private int _rangeEnd => Math.Min(_page * _pageSize, _total);
+
+    // A small window of page numbers around the current page (±2).
+    private IEnumerable<int> PageWindow()
+    {
+        const int span = 2;
+        var start = Math.Max(1, _page - span);
+        var end = Math.Min(_totalPages, _page + span);
+        for (var p = start; p <= end; p++) yield return p;
+    }
 
     protected override async Task OnInitializedAsync()
     {
         TopBar.Set("Activity", Actions);
+        _accounts = await Api.GetAsync<List<AccountDto>>("/api/accounts") ?? [];
         await Load();
     }
 
@@ -64,17 +122,52 @@
 
     private async Task Load()
     {
-        var txTask = Api.GetAsync<List<TransactionDto>>("/api/transactions?limit=200");
-        var acctTask = Api.GetAsync<List<AccountDto>>("/api/accounts");
-        await Task.WhenAll(txTask, acctTask);
-        _transactions = await txTask ?? [];
-        _accounts = await acctTask ?? [];
+        _loading = true;
+        StateHasChanged();
+
+        var query = new List<string> { $"page={_page}", $"page_size={_pageSize}" };
+        if (_acct != "All" && _accounts.FirstOrDefault(a => a.Name == _acct)?.Id is int accountId)
+            query.Add($"account_id={accountId}");
+        if (_type != "All") query.Add($"type={Uri.EscapeDataString(_type)}");
+        if (!string.IsNullOrWhiteSpace(_search)) query.Add($"search={Uri.EscapeDataString(_search.Trim())}");
+
+        var (items, total) = await Api.GetWithCountAsync<List<TransactionDto>>("/api/transactions?" + string.Join("&", query));
+        _transactions = items ?? [];
+        _total = total;
+        // If a filter shrank the result set below the current page, step back into range.
+        if (_page > _totalPages) { _page = _totalPages; await Load(); return; }
         _loading = false;
+        StateHasChanged();
     }
 
-    private void OnSearch(ChangeEventArgs e) => _search = e.Value?.ToString() ?? "";
-    private void OnAcct(ChangeEventArgs e) => _acct = e.Value?.ToString() ?? "All";
-    private void OnType(ChangeEventArgs e) => _type = e.Value?.ToString() ?? "All";
+    private async Task GoTo(int page)
+    {
+        var target = Math.Clamp(page, 1, _totalPages);
+        if (target == _page) return;
+        _page = target;
+        await Load();
+    }
+
+    private async Task OnSearch(ChangeEventArgs e)
+    {
+        _search = e.Value?.ToString() ?? "";
+        _searchDebounce.Cancel();
+        _searchDebounce = new CancellationTokenSource();
+        var token = _searchDebounce.Token;
+        try { await Task.Delay(350, token); }
+        catch (TaskCanceledException) { return; }
+        _page = 1;
+        await Load();
+    }
+
+    private async Task OnAcct(ChangeEventArgs e) { _acct = e.Value?.ToString() ?? "All"; _page = 1; await Load(); }
+    private async Task OnType(ChangeEventArgs e) { _type = e.Value?.ToString() ?? "All"; _page = 1; await Load(); }
+    private async Task OnPageSize(ChangeEventArgs e)
+    {
+        _pageSize = int.TryParse(e.Value?.ToString(), out var size) ? size : 25;
+        _page = 1;
+        await Load();
+    }
 
     private void Export() => JS.InvokeVoidAsync("capitrack.go", "/api/transactions/export/csv");
 
@@ -104,7 +197,7 @@
 
     private async Task DeleteTx(TransactionDto tx)
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Delete this transaction?")) return;
+        if (!await Confirm.AskAsync("Delete transaction", $"Delete the {tx.Type} of {tx.Symbol}? This can't be undone.", "Delete", danger: true)) return;
         await Api.DeleteAsync<object>($"/api/transactions/{tx.Id}");
         Toast.Show("Transaction deleted", "success");
         await Load();

--- a/src/client/Client.Presentation/Pages/Activity.razor
+++ b/src/client/Client.Presentation/Pages/Activity.razor
@@ -178,7 +178,7 @@
         {
             Id = tx.Id, Symbol = tx.Symbol, Type = tx.Type, Date = tx.Date.Split('T')[0],
             Quantity = tx.Quantity, Price = tx.Price, Fee = tx.Fee, Currency = tx.Currency, Notes = tx.Notes,
-            TagIds = tx.Tags.Select(t => t.Id).ToHashSet()
+            IsStaked = tx.IsStaked, TagIds = tx.Tags.Select(t => t.Id).ToHashSet()
         };
         Modal.Show("Edit Transaction", @<TransactionForm Model="model" Tags="_tags" OnSave="() => SaveEdit(tx.Id, model)" />);
     }
@@ -188,7 +188,7 @@
         await Api.PutAsync<TransactionDto>($"/api/transactions/{id}", new
         {
             symbol = m.Symbol, type = m.Type, date = m.Date, quantity = m.Quantity ?? 0,
-            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, tag_ids = m.TagIds.ToList()
+            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, is_staked = m.IsStaked, tag_ids = m.TagIds.ToList()
         });
         Modal.Close();
         Toast.Show("Transaction updated", "success");

--- a/src/client/Client.Presentation/Pages/Settings.razor
+++ b/src/client/Client.Presentation/Pages/Settings.razor
@@ -8,6 +8,7 @@
 @inject TopBarState TopBar
 @inject ModalService Modal
 @inject ToastService Toast
+@inject ConfirmService Confirm
 @inject SettingsStore Prefs
 @inject IJSRuntime JS
 
@@ -122,6 +123,73 @@
                         <button class="btn btn-pri btn-sm" @onclick="SaveDbPath"><Icon Name="check" /> Save Path</button>
                         <button class="btn btn-ghost btn-sm" @onclick="RefreshPlatform"><Icon Name="refresh" /> Refresh Platform</button>
                     </div>
+
+                    <div style="height:1px;background:var(--border);margin:22px 0;"></div>
+
+                    <div style="font-weight:600;font-size:0.92rem;margin-bottom:4px;">Backup &amp; restore</div>
+                    <p class="sub" style="margin-bottom:14px;">Export a full JSON snapshot of your data (accounts, transactions, tags, goals, currency rates and daily wealth), or restore from a previous export.</p>
+
+                    <SettingsRow Title="Export data" Sub="Download everything as a single JSON backup file.">
+                        <button class="btn btn-pri btn-sm" @onclick="ExportData"><Icon Name="download" /> Export JSON</button>
+                    </SettingsRow>
+
+                    <div class="mt-4" style="border:1px solid var(--down);background:var(--down-soft);border-radius:var(--r-sm);padding:15px 16px;">
+                        <div class="flex gap-2" style="align-items:center;color:var(--down);font-weight:700;font-size:0.9rem;margin-bottom:8px;"><Icon Name="skull" Width="16" Height="16" /> Replace all data</div>
+                        <p class="sub" style="margin-bottom:13px;">Importing a backup <strong style="color:var(--text-2);">permanently replaces every account, transaction, tag, goal and currency rate</strong> with the contents of the file. This cannot be undone — export a backup first.</p>
+                        <div class="field" style="margin-bottom:12px;">
+                            <InputFile OnChange="OnBackupSelected" accept=".json,application/json" class="input" style="padding:9px 13px;height:auto;" />
+                        </div>
+                        @if (_backupFile is not null)
+                        {
+                            <p class="sub" style="margin-bottom:10px;"><Icon Name="info" Width="13" Height="13" /> Selected: <strong style="color:var(--text-2);">@_backupFile.Name</strong></p>
+                        }
+                        <button class="btn btn-danger btn-sm" @onclick="ImportData" disabled="@(_backupFile is null || _importBusy)">
+                            <Icon Name="upload" /> @(_importBusy ? "Replacing…" : "Import & replace all data")
+                        </button>
+                    </div>
+                </SettingsPanel>
+            }
+            else if (_panel == "providers")
+            {
+                <SettingsPanel IconName="trend" Title="Market Data">
+                    <p class="sub" style="margin-bottom:16px;line-height:1.6;">Capitrack fetches live and historical prices for your holdings from the provider below. Support for additional providers — each with its own API key and enable/disable switch — is on the way.</p>
+                    @if (_providers.Count == 0)
+                    {
+                        <div class="empty-state"><Icon Name="trend" /><p>No market-data providers configured.</p></div>
+                    }
+                    @foreach (var p in _providers)
+                    {
+                        <div class="card card-pad mt-3">
+                            <div class="flex gap-3" style="align-items:flex-start;">
+                                <div style="flex-shrink:0;width:40px;height:40px;border-radius:10px;display:flex;align-items:center;justify-content:center;background:var(--pri-soft);color:var(--pri-2);"><Icon Name="trend" Width="20" Height="20" /></div>
+                                <div style="flex:1;min-width:0;">
+                                    <div class="flex gap-2" style="align-items:center;flex-wrap:wrap;">
+                                        <span style="font-weight:700;font-size:0.98rem;">@p.Name</span>
+                                        @if (p.IsDefault)
+                                        {
+                                            <span class="chip" style="color:var(--pri-2);background:var(--pri-soft);">Default</span>
+                                        }
+                                        @if (p.Enabled)
+                                        {
+                                            <span class="chip up"><Icon Name="check" Width="12" Height="12" /> Active</span>
+                                        }
+                                    </div>
+                                    <p class="sub" style="margin-top:6px;line-height:1.55;">@p.Description</p>
+                                    <div class="flex gap-4 mt-3" style="flex-wrap:wrap;align-items:center;">
+                                        <span class="sub"><Icon Name="lock" Width="13" Height="13" /> @(p.RequiresApiKey ? (p.ApiKeySet ? "API key configured" : "API key required") : "No API key required")</span>
+                                        @if (!string.IsNullOrEmpty(p.Website))
+                                        {
+                                            <a class="sub" style="color:var(--pri-2);" href="@p.Website" target="_blank" rel="noopener"><Icon Name="external" Width="13" Height="13" /> Provider site</a>
+                                        }
+                                    </div>
+                                </div>
+                                <button type="button" role="switch" aria-checked="@(p.Enabled ? "true" : "false")" disabled title="More providers and toggles are coming soon"
+                                        style="@($"flex-shrink:0;width:42px;height:24px;border-radius:99px;border:none;cursor:not-allowed;padding:0;position:relative;background:{(p.Enabled ? "var(--pri)" : "var(--surface-3)")};opacity:0.9;")">
+                                    <i style="@($"position:absolute;top:3px;left:{(p.Enabled ? "21px" : "3px")};width:18px;height:18px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,0.3);")"></i>
+                                </button>
+                            </div>
+                        </div>
+                    }
                 </SettingsPanel>
             }
             else if (_panel == "appearance")
@@ -179,7 +247,15 @@
                             <div class="sub">Version @_version · MIT License</div>
                         </div>
                         <p class="sub" style="max-width:380px;">Open-source, self-hosted wealth tracking for everyone. Your portfolio, your server, your data.</p>
-                        <a class="btn btn-ghost btn-sm" href="https://github.com/jeff-nasseri/Capitrack" target="_blank" rel="noopener"><Icon Name="external" /> View on GitHub</a>
+                        <div class="flex gap-2" style="flex-wrap:wrap;justify-content:center;">
+                            <a class="btn btn-ghost btn-sm" href="https://capitrack.dev" target="_blank" rel="noopener"><Icon Name="external" /> Website</a>
+                            <a class="btn btn-ghost btn-sm" href="https://capitrack.dev/docs/getting-started.html" target="_blank" rel="noopener"><Icon Name="info" /> Documentation</a>
+                            <a class="btn btn-ghost btn-sm" href="https://github.com/jeff-nasseri/Capitrack" target="_blank" rel="noopener"><Icon Name="external" /> GitHub</a>
+                        </div>
+                        <div class="flex gap-4" style="margin-top:6px;">
+                            <a class="sub" style="color:var(--pri-2);" href="https://capitrack.dev" target="_blank" rel="noopener">capitrack.dev</a>
+                            <a class="sub" style="color:var(--pri-2);" href="https://capitrack.dev/docs/getting-started.html" target="_blank" rel="noopener">capitrack.dev/docs</a>
+                        </div>
                     </div>
                 </SettingsPanel>
             }
@@ -203,6 +279,7 @@
     [
         ("accounts", "Accounts", "wallet"), ("goals", "Goals", "goals"), ("tags", "Tags", "tag"),
         ("currencies", "Currency Rates", "swap"), ("database", "Database", "database"),
+        ("providers", "Market Data", "trend"),
         ("appearance", "Appearance", "palette"), ("security", "Security", "lock"),
         ("about", "About", "info"), ("danger", "Danger Zone", "skull")
     ];
@@ -232,6 +309,9 @@
     private string _curPw = "", _newPw = "", _confirmPw = "";
     private string? _pwMsg;
     private bool _pwOk;
+    private List<MarketDataProviderDto> _providers = [];
+    private IBrowserFile? _backupFile;
+    private bool _importBusy;
 
     protected override async Task OnInitializedAsync()
     {
@@ -247,6 +327,7 @@
             _dbHealthy = db.Exists;
             _dbStatus = db.Exists ? "Database file exists and is accessible." : "Database file will be created at this location.";
         }
+        _providers = await Api.GetAsync<List<MarketDataProviderDto>>("/api/settings/providers") ?? [];
         await LoadAll();
     }
 
@@ -292,7 +373,7 @@
 
     private async Task DeleteAccount(int id)
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Delete this account and all its transactions?")) return;
+        if (!await Confirm.AskAsync("Delete account", "This permanently deletes the account and all of its transactions.", "Delete", danger: true)) return;
         await Api.DeleteAsync<object>($"/api/accounts/{id}");
         Toast.Show("Account deleted", "success");
         await LoadAll();
@@ -321,7 +402,7 @@
 
     private async Task DeleteGoal(int id)
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Delete this goal?")) return;
+        if (!await Confirm.AskAsync("Delete goal", "This goal will be permanently removed.", "Delete", danger: true)) return;
         await Api.DeleteAsync<object>($"/api/goals/{id}");
         Toast.Show("Goal deleted", "success");
         await LoadAll();
@@ -329,8 +410,7 @@
 
     private async Task RemoveAllGoals()
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "WARNING: This will permanently delete ALL goals. This action cannot be undone.\n\nAre you sure?")) return;
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Final confirmation: All goals will be permanently deleted.")) return;
+        if (!await Confirm.AskAsync("Remove all goals", "This permanently deletes ALL goals. This action cannot be undone.", "Delete all", danger: true)) return;
         await Api.DeleteAsync<object>("/api/goals");
         Toast.Show("All goals removed", "success");
         await LoadAll();
@@ -355,7 +435,7 @@
 
     private async Task DeleteTag(int id)
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Delete this tag?")) return;
+        if (!await Confirm.AskAsync("Delete tag", "This tag will be removed from every item it's applied to.", "Delete", danger: true)) return;
         await Api.DeleteAsync<object>($"/api/tags/{id}");
         Toast.Show("Tag deleted", "success");
         await LoadAll();
@@ -380,7 +460,7 @@
 
     private async Task DeleteRate(int id)
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Delete this rate?")) return;
+        if (!await Confirm.AskAsync("Delete currency rate", "This conversion rate will be permanently removed.", "Delete", danger: true)) return;
         await Api.DeleteAsync<object>($"/api/currencies/{id}");
         Toast.Show("Rate deleted", "success");
         await LoadAll();
@@ -421,16 +501,50 @@
 
     private async Task RefreshPlatform()
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Refresh the platform with the current database?")) return;
+        if (!await Confirm.AskAsync("Refresh platform", "Reload the platform using the current database. The page will refresh.", "Refresh", danger: false, icon: "refresh")) return;
         await Api.PostAsync<object>("/api/settings/refresh", new { });
         await JS.InvokeVoidAsync("capitrack.reload");
+    }
+
+    // ---- Backup & restore ----
+    private void ExportData() => JS.InvokeVoidAsync("capitrack.go", "/api/settings/database/export");
+
+    private void OnBackupSelected(InputFileChangeEventArgs e) => _backupFile = e.File;
+
+    private async Task ImportData()
+    {
+        if (_backupFile is null) return;
+        if (!await Confirm.AskAsync("Replace all data",
+                $"This permanently replaces ALL of your data with the contents of \"{_backupFile.Name}\". This cannot be undone.",
+                "Replace everything", danger: true, icon: "skull")) return;
+
+        _importBusy = true;
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            content.Add(new StreamContent(_backupFile.OpenReadStream(25 * 1024 * 1024)), "file", _backupFile.Name);
+            var (ok, json) = await Api.PostFormWithStatusAsync<JsonElement>("/api/settings/database/import", content);
+            if (ok)
+            {
+                var msg = json.ValueKind == JsonValueKind.Object && json.TryGetProperty("message", out var m) ? m.GetString() : null;
+                Toast.Show(msg ?? "Data replaced from backup", "success");
+                _backupFile = null;
+                await LoadAll();
+            }
+            else
+            {
+                var err = json.ValueKind == JsonValueKind.Object && json.TryGetProperty("error", out var er) ? er.GetString() : null;
+                Toast.Show(err ?? "Import failed — check the file and try again", "error");
+            }
+        }
+        catch { Toast.Show("Import failed — invalid or unreadable file", "error"); }
+        finally { _importBusy = false; }
     }
 
     // ---- Danger ----
     private async Task Purge()
     {
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "WARNING: This will permanently delete ALL accounts, transactions, goals, and cached data. This action cannot be undone.\n\nAre you absolutely sure?")) return;
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Final confirmation: Type OK to proceed.\n\nAll data will be lost permanently.")) return;
+        if (!await Confirm.AskAsync("Purge all data", "This permanently deletes EVERY account, transaction, goal and cached price. This cannot be undone.", "Purge everything", danger: true, icon: "skull")) return;
         await Api.DeleteAsync<object>("/api/accounts/purge/all");
         State.Accounts = []; State.AllHoldings = []; State.DashboardSummary = null;
         Toast.Show("All data has been purged", "success");

--- a/src/client/Client.Presentation/Pages/SymbolDetail.razor
+++ b/src/client/Client.Presentation/Pages/SymbolDetail.razor
@@ -257,7 +257,7 @@
         await Api.PostAsync<TransactionDto>("/api/transactions", new
         {
             account_id = AccountId, symbol = m.Symbol, type = m.Type, date = m.Date, quantity = m.Quantity ?? 0,
-            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, tag_ids = m.TagIds.ToList()
+            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, is_staked = m.IsStaked, tag_ids = m.TagIds.ToList()
         });
         Modal.Close();
         Toast.Show("Transaction added", "success");
@@ -272,7 +272,7 @@
         {
             Id = tx.Id, Symbol = tx.Symbol, Type = tx.Type, Date = tx.Date.Split('T')[0],
             Quantity = tx.Quantity, Price = tx.Price, Fee = tx.Fee, Currency = tx.Currency, Notes = tx.Notes,
-            TagIds = tx.Tags.Select(t => t.Id).ToHashSet()
+            IsStaked = tx.IsStaked, TagIds = tx.Tags.Select(t => t.Id).ToHashSet()
         };
         Modal.Show("Edit Transaction", @<TransactionForm Model="model" Tags="_tags" OnSave="() => SaveEdit(tx.Id, model)" />);
     }
@@ -282,7 +282,7 @@
         await Api.PutAsync<TransactionDto>($"/api/transactions/{id}", new
         {
             symbol = m.Symbol, type = m.Type, date = m.Date, quantity = m.Quantity ?? 0,
-            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, tag_ids = m.TagIds.ToList()
+            price = m.Price ?? 0, fee = m.Fee, currency = m.Currency, notes = m.Notes, is_staked = m.IsStaked, tag_ids = m.TagIds.ToList()
         });
         Modal.Close();
         Toast.Show("Transaction updated", "success");

--- a/src/client/Client.Presentation/Pages/SymbolDetail.razor
+++ b/src/client/Client.Presentation/Pages/SymbolDetail.razor
@@ -4,6 +4,7 @@
 @inject AppState State
 @inject ModalService Modal
 @inject ToastService Toast
+@inject ConfirmService Confirm
 @inject TopBarState TopBar
 @inject NavigationManager Nav
 @inject IJSRuntime JS
@@ -291,7 +292,7 @@
     private async Task DeleteTx(TransactionDto tx)
     {
         _openTxId = null;
-        if (!await JS.InvokeAsync<bool>("capitrack.confirm", "Delete this transaction?")) return;
+        if (!await Confirm.AskAsync("Delete transaction", $"Delete the {tx.Type} of {tx.Symbol}? This can't be undone.", "Delete", danger: true)) return;
         await Api.DeleteAsync<object>($"/api/transactions/{tx.Id}");
         Toast.Show("Transaction deleted", "success");
         await Reload();

--- a/src/client/Client.Presentation/Program.cs
+++ b/src/client/Client.Presentation/Program.cs
@@ -23,6 +23,7 @@ builder.Services.AddScoped<IApiClient>(sp => sp.GetRequiredService<ApiClient>())
 builder.Services.AddScoped<AppState>();
 builder.Services.AddScoped<ToastService>();
 builder.Services.AddScoped<ModalService>();
+builder.Services.AddScoped<ConfirmService>();
 builder.Services.AddScoped<SettingsStore>();
 builder.Services.AddScoped<TopBarState>();
 

--- a/src/server/Server.Api/Controllers/SettingsController.cs
+++ b/src/server/Server.Api/Controllers/SettingsController.cs
@@ -1,12 +1,22 @@
+using System.Text.Json;
 using Server.Application.Settings.Commands;
 using Server.Application.Settings.Queries;
 
 namespace Server.Api.Controllers;
 
 [ApiController]
+[Authorize]
 [Route("api/settings")]
 public sealed class SettingsController(IMediator mediator) : ControllerBase
 {
+    // snake_case + indented, so exported backups are readable and round-trip through import.
+    private static readonly JsonSerializerOptions BackupJson = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
     [HttpGet]
     public async Task<IActionResult> Info() => Ok(await mediator.Send(new GetSettingsInfoQuery()));
 
@@ -17,8 +27,46 @@ public sealed class SettingsController(IMediator mediator) : ControllerBase
     public async Task<IActionResult> SetDatabase([FromBody] SetDatabaseCommand command) =>
         Ok(await mediator.Send(command));
 
+    /// <summary>Downloads a full JSON snapshot of all portfolio data.</summary>
+    [HttpGet("database/export")]
+    public async Task<IActionResult> ExportDatabase()
+    {
+        var snapshot = await mediator.Send(new ExportDatabaseQuery());
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(snapshot, BackupJson);
+        var name = $"capitrack-backup-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json";
+        return File(bytes, "application/json", name);
+    }
+
+    /// <summary>Replaces ALL portfolio data with the contents of an uploaded backup file.</summary>
+    [HttpPost("database/import")]
+    public async Task<IActionResult> ImportDatabase([FromForm] IFormFile? file)
+    {
+        if (file is null || file.Length == 0)
+            return BadRequest(new { error = "No backup file was uploaded." });
+
+        DatabaseSnapshot? snapshot;
+        try
+        {
+            await using var stream = file.OpenReadStream();
+            snapshot = await JsonSerializer.DeserializeAsync<DatabaseSnapshot>(stream, BackupJson);
+        }
+        catch (JsonException)
+        {
+            return BadRequest(new { error = "The file is not a valid Capitrack backup (could not parse JSON)." });
+        }
+
+        if (snapshot is null)
+            return BadRequest(new { error = "The file is not a valid Capitrack backup." });
+
+        return Ok(await mediator.Send(new ImportDatabaseCommand(snapshot)));
+    }
+
     [HttpPost("refresh")]
     public async Task<IActionResult> Refresh() => Ok(await mediator.Send(new RefreshCommand()));
+
+    /// <summary>Lists the market-data providers used for price lookups.</summary>
+    [HttpGet("providers")]
+    public async Task<IActionResult> Providers() => Ok(await mediator.Send(new GetProvidersQuery()));
 
     [HttpGet("about")]
     public async Task<IActionResult> About() => Ok(await mediator.Send(new GetAboutQuery()));

--- a/src/server/Server.Api/Controllers/TransactionsController.cs
+++ b/src/server/Server.Api/Controllers/TransactionsController.cs
@@ -13,9 +13,27 @@ public sealed class TransactionsController(IMediator mediator) : ControllerBase
     public async Task<IActionResult> List(
         [FromQuery(Name = "account_id")] int? accountId,
         [FromQuery] string? symbol,
+        [FromQuery] string? search,
+        [FromQuery] string? type,
         [FromQuery] int? limit,
-        [FromQuery] int? offset) =>
-        Ok(await mediator.Send(new GetTransactionsQuery(accountId, symbol, limit, offset)));
+        [FromQuery] int? offset,
+        [FromQuery] int? page,
+        [FromQuery(Name = "page_size")] int? pageSize)
+    {
+        // page/page_size, when valid, take precedence over raw limit/offset.
+        if (page is >= 1 && pageSize is >= 1)
+        {
+            offset = (page.Value - 1) * pageSize.Value;
+            limit = pageSize.Value;
+        }
+
+        // Always expose the unpaged total so the client can drive pagination.
+        var total = await mediator.Send(new GetTransactionsCountQuery(accountId, symbol, search, type));
+        Response.Headers.Append("X-Total-Count", total.ToString());
+
+        var items = await mediator.Send(new GetTransactionsQuery(accountId, symbol, search, type, limit, offset));
+        return Ok(items);
+    }
 
     [HttpGet("{id:int}")]
     public async Task<IActionResult> Get(int id) => Ok(await mediator.Send(new GetTransactionByIdQuery(id)));

--- a/src/server/Server.Api/Controllers/TransactionsController.cs
+++ b/src/server/Server.Api/Controllers/TransactionsController.cs
@@ -80,4 +80,53 @@ public sealed class TransactionsController(IMediator mediator) : ControllerBase
         var content = await reader.ReadToEndAsync();
         return Ok(await mediator.Send(new DetectCsvQuery(content)));
     }
+
+    /// <summary>Imports several CSV files into one account in a single call (aggregate result, dedup across files).</summary>
+    [HttpPost("import/csv/bulk")]
+    public async Task<IActionResult> ImportBulk(
+        [FromForm] IFormFileCollection files,
+        [FromForm(Name = "account_id")] int accountId,
+        [FromForm] string? format)
+    {
+        if (files is null || files.Count == 0) return BadRequest(new { error = "No files uploaded" });
+
+        int imported = 0, skipped = 0, total = 0;
+        var errors = new List<string>();
+        foreach (var file in files)
+        {
+            if (file.Length == 0) continue;
+            using var reader = new StreamReader(file.OpenReadStream());
+            var content = await reader.ReadToEndAsync();
+            var r = await mediator.Send(new ImportTransactionsCsvCommand(content, accountId, format));
+            imported += r.Imported;
+            skipped += r.Skipped;
+            total += r.Total;
+            if (r.Errors is { Count: > 0 }) errors.AddRange(r.Errors.Select(e => $"{file.FileName}: {e}"));
+        }
+        return Ok(new ImportResultDto(imported, skipped, total, errors, "bulk"));
+    }
+
+    /// <summary>Parses one or more CSV files WITHOUT importing, returning each file's rows (with duplicate + stake flags) for review.</summary>
+    [HttpPost("import/preview")]
+    public async Task<IActionResult> ImportPreview(
+        [FromForm] IFormFileCollection files,
+        [FromForm(Name = "account_id")] int accountId)
+    {
+        if (files is null || files.Count == 0) return BadRequest(new { error = "No files uploaded" });
+
+        var result = new List<PreviewFileDto>();
+        foreach (var file in files)
+        {
+            if (file.Length == 0) continue;
+            using var reader = new StreamReader(file.OpenReadStream());
+            var content = await reader.ReadToEndAsync();
+            result.Add(await mediator.Send(new PreviewImportCommand(file.FileName, content, accountId)));
+        }
+        return Ok(result);
+    }
+
+    /// <summary>Imports only the transactions the user selected in the Check &amp; Import preview (with per-row stake flags).</summary>
+    [HttpPost("import/selected")]
+    public async Task<IActionResult> ImportSelected([FromBody] ImportSelectedCommand command) =>
+        Ok(await mediator.Send(command));
 }

--- a/src/server/Server.Application/Common/Interfaces/IDatabaseBackupService.cs
+++ b/src/server/Server.Application/Common/Interfaces/IDatabaseBackupService.cs
@@ -1,0 +1,17 @@
+namespace Server.Application.Common.Interfaces;
+
+/// <summary>
+/// Exports all portfolio data to, and restores it from, a <see cref="DatabaseSnapshot"/>.
+/// Import is a destructive full replace of every portfolio table (auth rows are preserved).
+/// </summary>
+public interface IDatabaseBackupService
+{
+    /// <summary>Reads every portfolio table into a single self-contained snapshot.</summary>
+    Task<DatabaseSnapshot> ExportAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Destructively replaces all portfolio data with the contents of <paramref name="snapshot"/>.
+    /// Returns the per-entity counts actually imported.
+    /// </summary>
+    Task<ImportResult> ImportAsync(DatabaseSnapshot snapshot, CancellationToken ct);
+}

--- a/src/server/Server.Application/Common/Interfaces/IImporterService.cs
+++ b/src/server/Server.Application/Common/Interfaces/IImporterService.cs
@@ -8,4 +8,13 @@ public interface IImporterService
 
     /// <summary>Imports transactions from CSV content into an account, optionally with a format hint.</summary>
     Task<ImportResultDto> ImportAsync(string content, int accountId, string? formatHint);
+
+    /// <summary>
+    /// Parses (without importing) CSV content for an account and returns the detected format plus the
+    /// parsed rows, each flagged for whether it duplicates an existing transaction and whether it can be staked.
+    /// </summary>
+    Task<PreviewFileDto> PreviewAsync(string fileName, string content, int accountId);
+
+    /// <summary>Imports a set of user-selected transactions directly, applying the same fingerprint dedup against existing rows.</summary>
+    Task<ImportResultDto> ImportSelectedAsync(int accountId, IEnumerable<SelectedTransactionDto> transactions);
 }

--- a/src/server/Server.Application/Common/Interfaces/ITransactionRepository.cs
+++ b/src/server/Server.Application/Common/Interfaces/ITransactionRepository.cs
@@ -5,8 +5,11 @@ namespace Server.Application.Common.Interfaces;
 /// <summary>Persistence operations for <see cref="Transaction"/> aggregates and their tag links.</summary>
 public interface ITransactionRepository
 {
-    /// <summary>Returns transactions matching the optional account/symbol filters and paging.</summary>
-    Task<IReadOnlyList<Transaction>> ListAsync(int? accountId, string? symbol, int? limit, int? offset, CancellationToken ct = default);
+    /// <summary>Returns transactions matching the optional account/symbol/search/type filters and paging.</summary>
+    Task<IReadOnlyList<Transaction>> ListAsync(int? accountId, string? symbol, string? search, string? type, int? limit, int? offset, CancellationToken ct = default);
+
+    /// <summary>Counts all transactions matching the optional account/symbol/search/type filters, ignoring paging.</summary>
+    Task<int> CountAsync(int? accountId, string? symbol, string? search, string? type, CancellationToken ct = default);
 
     /// <summary>Returns all transactions for a single account.</summary>
     Task<IReadOnlyList<Transaction>> ForAccountAsync(int accountId, CancellationToken ct = default);

--- a/src/server/Server.Application/Settings/Commands/ImportDatabaseCommand.cs
+++ b/src/server/Server.Application/Settings/Commands/ImportDatabaseCommand.cs
@@ -1,0 +1,19 @@
+namespace Server.Application.Settings.Commands;
+
+/// <summary>Destructively replaces all portfolio data with the supplied snapshot.</summary>
+/// <param name="Snapshot">The snapshot whose contents become the new dataset.</param>
+public record ImportDatabaseCommand(DatabaseSnapshot Snapshot) : IRequest<ImportResult>;
+
+/// <summary>Handles <see cref="ImportDatabaseCommand"/>.</summary>
+public sealed class ImportDatabaseCommandHandler(
+    IDatabaseBackupService backup,
+    ILogger<ImportDatabaseCommandHandler> logger)
+    : IRequestHandler<ImportDatabaseCommand, ImportResult>
+{
+    /// <summary>Replaces every portfolio table with the snapshot and returns the imported counts.</summary>
+    public async Task<ImportResult> Handle(ImportDatabaseCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(ImportDatabaseCommand));
+        return await backup.ImportAsync(request.Snapshot, cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Settings/DatabaseSnapshot.cs
+++ b/src/server/Server.Application/Settings/DatabaseSnapshot.cs
@@ -1,0 +1,20 @@
+namespace Server.Application.Settings;
+
+/// <summary>A complete, self-contained snapshot of all portfolio data, used for export/import.</summary>
+/// <param name="Version">The snapshot schema version.</param>
+/// <param name="ExportedAt">When the snapshot was produced (UTC).</param>
+/// <param name="Accounts">All accounts.</param>
+/// <param name="Transactions">All transactions.</param>
+/// <param name="Tags">All tags.</param>
+/// <param name="Goals">All goals.</param>
+/// <param name="CurrencyRates">All FX rates.</param>
+/// <param name="DailyWealth">All daily wealth snapshots.</param>
+public record DatabaseSnapshot(
+    int Version,
+    DateTime ExportedAt,
+    List<SnapshotAccount> Accounts,
+    List<SnapshotTransaction> Transactions,
+    List<SnapshotTag> Tags,
+    List<SnapshotGoal> Goals,
+    List<SnapshotCurrencyRate> CurrencyRates,
+    List<SnapshotDailyWealth> DailyWealth);

--- a/src/server/Server.Application/Settings/ImportResult.cs
+++ b/src/server/Server.Application/Settings/ImportResult.cs
@@ -1,0 +1,18 @@
+namespace Server.Application.Settings;
+
+/// <summary>The outcome of a destructive database import, with per-entity counts.</summary>
+/// <param name="Accounts">The number of accounts imported.</param>
+/// <param name="Transactions">The number of transactions imported.</param>
+/// <param name="Tags">The number of tags imported.</param>
+/// <param name="Goals">The number of goals imported.</param>
+/// <param name="CurrencyRates">The number of FX rates imported.</param>
+/// <param name="DailyWealth">The number of daily wealth snapshots imported.</param>
+/// <param name="Message">A human-readable summary message.</param>
+public record ImportResult(
+    int Accounts,
+    int Transactions,
+    int Tags,
+    int Goals,
+    int CurrencyRates,
+    int DailyWealth,
+    string Message);

--- a/src/server/Server.Application/Settings/MarketDataProviderDto.cs
+++ b/src/server/Server.Application/Settings/MarketDataProviderDto.cs
@@ -1,0 +1,20 @@
+namespace Server.Application.Settings;
+
+/// <summary>Describes a market-data provider Capitrack can source live prices from.</summary>
+/// <param name="Id">A stable identifier (e.g. "yahoo-finance").</param>
+/// <param name="Name">The human-friendly provider name.</param>
+/// <param name="Description">A short description of what the provider offers.</param>
+/// <param name="Enabled">Whether the provider is currently active.</param>
+/// <param name="RequiresApiKey">Whether the provider needs an API key.</param>
+/// <param name="ApiKeySet">Whether an API key has already been configured.</param>
+/// <param name="Website">The provider's public website.</param>
+/// <param name="IsDefault">Whether this is the default provider used for price lookups.</param>
+public record MarketDataProviderDto(
+    string Id,
+    string Name,
+    string Description,
+    bool Enabled,
+    bool RequiresApiKey,
+    bool ApiKeySet,
+    string Website,
+    bool IsDefault);

--- a/src/server/Server.Application/Settings/Queries/ExportDatabaseQuery.cs
+++ b/src/server/Server.Application/Settings/Queries/ExportDatabaseQuery.cs
@@ -1,0 +1,18 @@
+namespace Server.Application.Settings.Queries;
+
+/// <summary>Produces a full <see cref="DatabaseSnapshot"/> of every portfolio table.</summary>
+public record ExportDatabaseQuery : IRequest<DatabaseSnapshot>;
+
+/// <summary>Handles <see cref="ExportDatabaseQuery"/>.</summary>
+public sealed class ExportDatabaseQueryHandler(
+    IDatabaseBackupService backup,
+    ILogger<ExportDatabaseQueryHandler> logger)
+    : IRequestHandler<ExportDatabaseQuery, DatabaseSnapshot>
+{
+    /// <summary>Reads the full portfolio dataset into a single snapshot.</summary>
+    public async Task<DatabaseSnapshot> Handle(ExportDatabaseQuery request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(ExportDatabaseQuery));
+        return await backup.ExportAsync(cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Settings/Queries/GetProvidersQuery.cs
+++ b/src/server/Server.Application/Settings/Queries/GetProvidersQuery.cs
@@ -1,0 +1,34 @@
+namespace Server.Application.Settings.Queries;
+
+/// <summary>Lists the market-data providers Capitrack can use for price lookups.</summary>
+public record GetProvidersQuery : IRequest<List<MarketDataProviderDto>>;
+
+/// <summary>Handles <see cref="GetProvidersQuery"/>.</summary>
+public sealed class GetProvidersQueryHandler(ILogger<GetProvidersQueryHandler> logger)
+    : IRequestHandler<GetProvidersQuery, List<MarketDataProviderDto>>
+{
+    /// <summary>
+    /// Returns the currently-supported providers. Today this is Yahoo Finance only; the shape
+    /// is deliberately list-based so future providers (with API keys and enable/disable toggles)
+    /// slot in without changing the contract.
+    /// </summary>
+    public Task<List<MarketDataProviderDto>> Handle(GetProvidersQuery request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(GetProvidersQuery));
+
+        var providers = new List<MarketDataProviderDto>
+        {
+            new(
+                Id: "yahoo-finance",
+                Name: "Yahoo Finance",
+                Description: "Real-time and historical market quotes for stocks, ETFs, crypto and commodities, sourced from Yahoo Finance. No API key required.",
+                Enabled: true,
+                RequiresApiKey: false,
+                ApiKeySet: false,
+                Website: "https://finance.yahoo.com",
+                IsDefault: true)
+        };
+
+        return Task.FromResult(providers);
+    }
+}

--- a/src/server/Server.Application/Settings/SnapshotAccount.cs
+++ b/src/server/Server.Application/Settings/SnapshotAccount.cs
@@ -1,0 +1,20 @@
+namespace Server.Application.Settings;
+
+/// <summary>A single account inside a <see cref="DatabaseSnapshot"/>.</summary>
+/// <param name="Id">The account's original identifier (remapped on import).</param>
+/// <param name="Name">The account's name.</param>
+/// <param name="Type">The account type string.</param>
+/// <param name="Currency">The account's base currency code.</param>
+/// <param name="Description">A free-text description.</param>
+/// <param name="Icon">The icon identifier.</param>
+/// <param name="Color">The account's hex color.</param>
+/// <param name="TagIds">The original tag ids linked to the account (remapped on import).</param>
+public record SnapshotAccount(
+    int Id,
+    string Name,
+    string Type,
+    string Currency,
+    string? Description,
+    string? Icon,
+    string Color,
+    List<int> TagIds);

--- a/src/server/Server.Application/Settings/SnapshotCurrencyRate.cs
+++ b/src/server/Server.Application/Settings/SnapshotCurrencyRate.cs
@@ -1,0 +1,12 @@
+namespace Server.Application.Settings;
+
+/// <summary>A single FX rate inside a <see cref="DatabaseSnapshot"/>.</summary>
+/// <param name="Id">The rate's original identifier (remapped on import).</param>
+/// <param name="FromCurrency">The source currency code.</param>
+/// <param name="ToCurrency">The target currency code.</param>
+/// <param name="Rate">The conversion rate from source to target.</param>
+public record SnapshotCurrencyRate(
+    int Id,
+    string FromCurrency,
+    string ToCurrency,
+    double Rate);

--- a/src/server/Server.Application/Settings/SnapshotDailyWealth.cs
+++ b/src/server/Server.Application/Settings/SnapshotDailyWealth.cs
@@ -1,0 +1,14 @@
+namespace Server.Application.Settings;
+
+/// <summary>A single daily wealth snapshot row inside a <see cref="DatabaseSnapshot"/>.</summary>
+/// <param name="Date">The snapshot date (yyyy-MM-dd).</param>
+/// <param name="Total">The total wealth on that date.</param>
+/// <param name="TotalCost">The total cost basis on that date.</param>
+/// <param name="BaseCurrency">The base currency the totals are expressed in.</param>
+/// <param name="Details">A JSON detail payload for the snapshot.</param>
+public record SnapshotDailyWealth(
+    string Date,
+    double Total,
+    double TotalCost,
+    string BaseCurrency,
+    string Details);

--- a/src/server/Server.Application/Settings/SnapshotGoal.cs
+++ b/src/server/Server.Application/Settings/SnapshotGoal.cs
@@ -1,0 +1,20 @@
+namespace Server.Application.Settings;
+
+/// <summary>A single goal inside a <see cref="DatabaseSnapshot"/>.</summary>
+/// <param name="Id">The goal's original identifier (remapped on import).</param>
+/// <param name="Title">The goal's title.</param>
+/// <param name="TargetAmount">The target amount to reach.</param>
+/// <param name="TargetDate">The due date (yyyy-MM-dd).</param>
+/// <param name="Description">A free-text description.</param>
+/// <param name="Achieved">Whether the goal has been achieved.</param>
+/// <param name="CategoryId">The optional owning category's identifier (left null on import).</param>
+/// <param name="TagIds">The original tag ids linked to the goal (remapped on import).</param>
+public record SnapshotGoal(
+    int Id,
+    string Title,
+    double TargetAmount,
+    string TargetDate,
+    string? Description,
+    bool Achieved,
+    int? CategoryId,
+    List<int> TagIds);

--- a/src/server/Server.Application/Settings/SnapshotTag.cs
+++ b/src/server/Server.Application/Settings/SnapshotTag.cs
@@ -1,0 +1,10 @@
+namespace Server.Application.Settings;
+
+/// <summary>A single tag inside a <see cref="DatabaseSnapshot"/>.</summary>
+/// <param name="Id">The tag's original identifier (remapped on import).</param>
+/// <param name="Name">The tag's name.</param>
+/// <param name="Color">The tag's hex color.</param>
+public record SnapshotTag(
+    int Id,
+    string Name,
+    string Color);

--- a/src/server/Server.Application/Settings/SnapshotTransaction.cs
+++ b/src/server/Server.Application/Settings/SnapshotTransaction.cs
@@ -1,0 +1,26 @@
+namespace Server.Application.Settings;
+
+/// <summary>A single transaction inside a <see cref="DatabaseSnapshot"/>.</summary>
+/// <param name="Id">The transaction's original identifier (remapped on import).</param>
+/// <param name="AccountId">The owning account's original identifier (remapped on import).</param>
+/// <param name="Symbol">The traded symbol.</param>
+/// <param name="Type">The transaction type string.</param>
+/// <param name="Quantity">The traded quantity.</param>
+/// <param name="Price">The unit price.</param>
+/// <param name="Fee">The transaction fee.</param>
+/// <param name="Currency">The transaction currency code.</param>
+/// <param name="Date">The trade date (yyyy-MM-dd).</param>
+/// <param name="Notes">Free-text notes.</param>
+/// <param name="TagIds">The original tag ids linked to the transaction (remapped on import).</param>
+public record SnapshotTransaction(
+    int Id,
+    int AccountId,
+    string Symbol,
+    string Type,
+    double Quantity,
+    double Price,
+    double Fee,
+    string Currency,
+    string Date,
+    string? Notes,
+    List<int> TagIds);

--- a/src/server/Server.Application/Transactions/Commands/CreateTransactionCommand.cs
+++ b/src/server/Server.Application/Transactions/Commands/CreateTransactionCommand.cs
@@ -14,10 +14,11 @@ namespace Server.Application.Transactions.Commands;
 /// <param name="Currency">The transaction currency code.</param>
 /// <param name="Date">The trade date (required, yyyy-MM-dd).</param>
 /// <param name="Notes">Free-text notes.</param>
+/// <param name="IsStaked">Whether this transaction represents staked crypto.</param>
 /// <param name="TagIds">The ids of tags to attach.</param>
 public record CreateTransactionCommand(
     int? AccountId, string? Symbol, string? Type, double? Quantity, double? Price,
-    double? Fee, string? Currency, string? Date, string? Notes, List<int>? TagIds)
+    double? Fee, string? Currency, string? Date, string? Notes, bool? IsStaked, List<int>? TagIds)
     : IRequest<TransactionDto>;
 
 /// <summary>Validates <see cref="CreateTransactionCommand"/>.</summary>
@@ -60,7 +61,8 @@ public sealed class CreateTransactionHandler(
             request.Fee ?? 0,
             CurrencyCode.CreateOrDefault(request.Currency, CurrencyCode.Eur),
             TradeDate.Create(request.Date),
-            request.Notes);
+            request.Notes,
+            request.IsStaked ?? false);
 
         await transactions.AddAsync(tx, cancellationToken);
         await uow.SaveChangesAsync(cancellationToken);

--- a/src/server/Server.Application/Transactions/Commands/ImportSelectedCommand.cs
+++ b/src/server/Server.Application/Transactions/Commands/ImportSelectedCommand.cs
@@ -1,0 +1,28 @@
+using Server.Application.Common.Exceptions;
+
+namespace Server.Application.Transactions.Commands;
+
+/// <summary>Imports a user-selected set of transactions (from a Check &amp; Import preview) into an account.</summary>
+/// <param name="AccountId">The target account's identifier.</param>
+/// <param name="Transactions">The transactions the user chose to import (with any per-row stake flags).</param>
+public record ImportSelectedCommand(int AccountId, List<SelectedTransactionDto> Transactions)
+    : IRequest<ImportResultDto>;
+
+/// <summary>Handles <see cref="ImportSelectedCommand"/>.</summary>
+public sealed class ImportSelectedHandler(
+    IAccountRepository accounts,
+    IImporterService importer,
+    ILogger<ImportSelectedHandler> logger)
+    : IRequestHandler<ImportSelectedCommand, ImportResultDto>
+{
+    /// <summary>Verifies the account exists, then imports the selected transactions (with fingerprint dedup).</summary>
+    public async Task<ImportResultDto> Handle(ImportSelectedCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(ImportSelectedCommand));
+
+        if (!await accounts.ExistsAsync(request.AccountId, cancellationToken))
+            throw new NotFoundException("Account not found");
+
+        return await importer.ImportSelectedAsync(request.AccountId, request.Transactions ?? []);
+    }
+}

--- a/src/server/Server.Application/Transactions/Commands/PreviewImportCommand.cs
+++ b/src/server/Server.Application/Transactions/Commands/PreviewImportCommand.cs
@@ -1,0 +1,22 @@
+namespace Server.Application.Transactions.Commands;
+
+/// <summary>Parses a single import file for preview (no insert), flagging duplicates and stake-eligible rows.</summary>
+/// <param name="FileName">The uploaded file's name.</param>
+/// <param name="Content">The raw CSV content.</param>
+/// <param name="AccountId">The account the rows would be imported into (for duplicate detection).</param>
+public record PreviewImportCommand(string FileName, string Content, int AccountId)
+    : IRequest<PreviewFileDto>;
+
+/// <summary>Handles <see cref="PreviewImportCommand"/>.</summary>
+public sealed class PreviewImportHandler(
+    IImporterService importer,
+    ILogger<PreviewImportHandler> logger)
+    : IRequestHandler<PreviewImportCommand, PreviewFileDto>
+{
+    /// <summary>Delegates to the importer's parse-only preview.</summary>
+    public async Task<PreviewFileDto> Handle(PreviewImportCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(PreviewImportCommand));
+        return await importer.PreviewAsync(request.FileName, request.Content, request.AccountId);
+    }
+}

--- a/src/server/Server.Application/Transactions/Commands/UpdateTransactionCommand.cs
+++ b/src/server/Server.Application/Transactions/Commands/UpdateTransactionCommand.cs
@@ -13,10 +13,11 @@ namespace Server.Application.Transactions.Commands;
 /// <param name="Currency">The new currency code, or null to keep the current value.</param>
 /// <param name="Date">The new trade date, or null to keep the current value.</param>
 /// <param name="Notes">The new notes, or null to keep the current value.</param>
+/// <param name="IsStaked">The new staked flag, or null to keep the current value.</param>
 /// <param name="TagIds">The ids of tags to attach.</param>
 public record UpdateTransactionCommand(
     int Id, string? Symbol, string? Type, double? Quantity, double? Price,
-    double? Fee, string? Currency, string? Date, string? Notes, List<int>? TagIds)
+    double? Fee, string? Currency, string? Date, string? Notes, bool? IsStaked, List<int>? TagIds)
     : IRequest<TransactionDto>;
 
 /// <summary>Handles <see cref="UpdateTransactionCommand"/>.</summary>
@@ -45,6 +46,7 @@ public sealed class UpdateTransactionHandler(
         var currency = request.Currency ?? t.Currency.Value;
         var date = request.Date ?? t.Date.Value;
         var notes = request.Notes ?? t.Notes;
+        var isStaked = request.IsStaked ?? t.IsStaked;
 
         t.Update(
             Symbol.Create(symbol),
@@ -54,7 +56,8 @@ public sealed class UpdateTransactionHandler(
             fee,
             CurrencyCode.Create(currency),
             TradeDate.Create(date),
-            notes);
+            notes,
+            isStaked);
 
         await uow.SaveChangesAsync(cancellationToken);
 

--- a/src/server/Server.Application/Transactions/PreviewFileDto.cs
+++ b/src/server/Server.Application/Transactions/PreviewFileDto.cs
@@ -1,0 +1,7 @@
+namespace Server.Application.Transactions;
+
+/// <summary>The preview of a single import file: its detected format and parsed (un-imported) rows.</summary>
+/// <param name="FileName">The uploaded file's name.</param>
+/// <param name="Format">The detected CSV format identifier.</param>
+/// <param name="Transactions">The parsed transaction rows.</param>
+public record PreviewFileDto(string FileName, string Format, List<PreviewTransactionDto> Transactions);

--- a/src/server/Server.Application/Transactions/PreviewTransactionDto.cs
+++ b/src/server/Server.Application/Transactions/PreviewTransactionDto.cs
@@ -1,0 +1,17 @@
+namespace Server.Application.Transactions;
+
+/// <summary>A single parsed-but-not-yet-imported transaction row from an import file preview.</summary>
+/// <param name="Index">The zero-based position of the row within its file.</param>
+/// <param name="Symbol">The parsed symbol.</param>
+/// <param name="Type">The parsed transaction type string.</param>
+/// <param name="Quantity">The parsed quantity.</param>
+/// <param name="Price">The parsed unit price.</param>
+/// <param name="Fee">The parsed fee.</param>
+/// <param name="Currency">The parsed currency code.</param>
+/// <param name="Date">The parsed trade date (yyyy-MM-dd).</param>
+/// <param name="Notes">The parsed notes.</param>
+/// <param name="IsDuplicate">True when the row's fingerprint already exists in the target account.</param>
+/// <param name="CanStake">True when the row may be flagged as staked (an outgoing crypto transfer).</param>
+public record PreviewTransactionDto(
+    int Index, string Symbol, string Type, double Quantity, double Price, double Fee,
+    string Currency, string Date, string Notes, bool IsDuplicate, bool CanStake);

--- a/src/server/Server.Application/Transactions/Queries/ExportTransactionsCsvQuery.cs
+++ b/src/server/Server.Application/Transactions/Queries/ExportTransactionsCsvQuery.cs
@@ -22,7 +22,7 @@ public sealed class ExportTransactionsCsvQueryHandler(
     {
         logger.LogInformation("Handling {Request}", nameof(ExportTransactionsCsvQuery));
 
-        var items = await transactions.ListAsync(request.AccountId, null, null, null, cancellationToken);
+        var items = await transactions.ListAsync(request.AccountId, null, null, null, null, null, cancellationToken);
         var names = (await accounts.ListAsync(cancellationToken)).ToDictionary(a => a.Id, a => a.Name);
 
         var sb = new StringBuilder();

--- a/src/server/Server.Application/Transactions/Queries/GetTransactionsCountQuery.cs
+++ b/src/server/Server.Application/Transactions/Queries/GetTransactionsCountQuery.cs
@@ -1,0 +1,24 @@
+namespace Server.Application.Transactions.Queries;
+
+/// <summary>Returns the total number of transactions matching the optional filters, ignoring paging.</summary>
+/// <param name="AccountId">An optional account filter.</param>
+/// <param name="Symbol">An optional exact-symbol filter.</param>
+/// <param name="Search">An optional case-insensitive CONTAINS filter on the symbol.</param>
+/// <param name="Type">An optional exact transaction-type filter (e.g. "buy").</param>
+public record GetTransactionsCountQuery(int? AccountId, string? Symbol, string? Search, string? Type)
+    : IRequest<int>;
+
+/// <summary>Handles <see cref="GetTransactionsCountQuery"/>.</summary>
+public sealed class GetTransactionsCountQueryHandler(
+    ITransactionRepository transactions,
+    ILogger<GetTransactionsCountQueryHandler> logger)
+    : IRequestHandler<GetTransactionsCountQuery, int>
+{
+    /// <summary>Counts every transaction matching the filters, ignoring paging.</summary>
+    public async Task<int> Handle(GetTransactionsCountQuery request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(GetTransactionsCountQuery));
+
+        return await transactions.CountAsync(request.AccountId, request.Symbol, request.Search, request.Type, cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Transactions/Queries/GetTransactionsQuery.cs
+++ b/src/server/Server.Application/Transactions/Queries/GetTransactionsQuery.cs
@@ -2,12 +2,14 @@ using Server.Application.Tags;
 
 namespace Server.Application.Transactions.Queries;
 
-/// <summary>Returns transactions matching the optional account/symbol filters and paging.</summary>
+/// <summary>Returns transactions matching the optional account/symbol/search/type filters and paging.</summary>
 /// <param name="AccountId">An optional account filter.</param>
-/// <param name="Symbol">An optional symbol filter.</param>
+/// <param name="Symbol">An optional exact-symbol filter.</param>
+/// <param name="Search">An optional case-insensitive CONTAINS filter on the symbol.</param>
+/// <param name="Type">An optional exact transaction-type filter (e.g. "buy").</param>
 /// <param name="Limit">An optional page size.</param>
 /// <param name="Offset">An optional page offset.</param>
-public record GetTransactionsQuery(int? AccountId, string? Symbol, int? Limit, int? Offset)
+public record GetTransactionsQuery(int? AccountId, string? Symbol, string? Search, string? Type, int? Limit, int? Offset)
     : IRequest<List<TransactionDto>>;
 
 /// <summary>Handles <see cref="GetTransactionsQuery"/>.</summary>
@@ -24,7 +26,7 @@ public sealed class GetTransactionsQueryHandler(
     {
         logger.LogInformation("Handling {Request}", nameof(GetTransactionsQuery));
 
-        var items = await transactions.ListAsync(request.AccountId, request.Symbol, request.Limit, request.Offset, cancellationToken);
+        var items = await transactions.ListAsync(request.AccountId, request.Symbol, request.Search, request.Type, request.Limit, request.Offset, cancellationToken);
         var names = (await accounts.ListAsync(cancellationToken)).ToDictionary(a => a.Id, a => a.Name);
 
         var result = new List<TransactionDto>(items.Count);

--- a/src/server/Server.Application/Transactions/SelectedTransactionDto.cs
+++ b/src/server/Server.Application/Transactions/SelectedTransactionDto.cs
@@ -1,0 +1,15 @@
+namespace Server.Application.Transactions;
+
+/// <summary>A user-selected transaction to import directly (no CSV parsing).</summary>
+/// <param name="Symbol">The traded symbol.</param>
+/// <param name="Type">The transaction type string.</param>
+/// <param name="Quantity">The traded quantity.</param>
+/// <param name="Price">The unit price.</param>
+/// <param name="Fee">The transaction fee.</param>
+/// <param name="Currency">The currency code.</param>
+/// <param name="Date">The trade date (yyyy-MM-dd).</param>
+/// <param name="Notes">Optional free-text notes.</param>
+/// <param name="IsStaked">Whether this transaction represents staked crypto.</param>
+public record SelectedTransactionDto(
+    string Symbol, string Type, double Quantity, double Price, double Fee,
+    string Currency, string Date, string? Notes, bool IsStaked);

--- a/src/server/Server.Application/Transactions/TransactionDto.cs
+++ b/src/server/Server.Application/Transactions/TransactionDto.cs
@@ -13,10 +13,11 @@ namespace Server.Application.Transactions;
 /// <param name="Currency">The transaction currency code.</param>
 /// <param name="Date">The trade date (yyyy-MM-dd).</param>
 /// <param name="Notes">Free-text notes.</param>
+/// <param name="IsStaked">Whether this transaction represents staked crypto.</param>
 /// <param name="CreatedAt">When the record was created.</param>
 /// <param name="AccountName">The owning account's name, if resolved.</param>
 /// <param name="Tags">The tags attached to the transaction.</param>
 public record TransactionDto(
     int Id, int AccountId, string Symbol, string Type, double Quantity, double Price,
-    double Fee, string Currency, string Date, string Notes, DateTime CreatedAt,
+    double Fee, string Currency, string Date, string Notes, bool IsStaked, DateTime CreatedAt,
     string? AccountName, List<TagDto> Tags);

--- a/src/server/Server.Domain/Accounts/AccountType.cs
+++ b/src/server/Server.Domain/Accounts/AccountType.cs
@@ -24,6 +24,9 @@ public sealed class AccountType : ValueObject
 
     private static readonly IReadOnlyList<AccountType> Known = new[] { General, Stock, Crypto, Commodity, Cash };
 
+    /// <summary>True for cash-like accounts (cash / savings) that are valued at balance, never via a market quote.</summary>
+    public bool IsCash => Value is "cash" or "savings";
+
     /// <summary>Parses an account type, defaulting to <see cref="General"/> and accepting unknown values verbatim (lower-cased).</summary>
     public static AccountType From(string? value)
     {

--- a/src/server/Server.Domain/Holdings/HoldingsCalculator.cs
+++ b/src/server/Server.Domain/Holdings/HoldingsCalculator.cs
@@ -17,7 +17,7 @@ public static class HoldingsCalculator
         foreach (var g in transactions.GroupBy(t => t.Symbol))
         {
             double buyQty = g.Where(t => t.Type.IncreasesQuantity).Sum(t => t.Quantity.Value);
-            double sellQty = g.Where(t => t.Type.DecreasesQuantity).Sum(t => t.Quantity.Value);
+            double sellQty = g.Where(t => t.Type.DecreasesQuantity && !t.IsStaked).Sum(t => t.Quantity.Value);
             double quantity = buyQty - sellQty;
             if (quantity <= Epsilon) continue;
 
@@ -44,7 +44,7 @@ public static class HoldingsCalculator
         foreach (var g in transactions.GroupBy(t => new { t.Symbol, t.AccountId }))
         {
             double buyQty = g.Where(t => t.Type.IncreasesQuantity).Sum(t => t.Quantity.Value);
-            double sellQty = g.Where(t => t.Type.DecreasesQuantity).Sum(t => t.Quantity.Value);
+            double sellQty = g.Where(t => t.Type.DecreasesQuantity && !t.IsStaked).Sum(t => t.Quantity.Value);
             double quantity = buyQty - sellQty;
             if (quantity <= Epsilon) continue;
 

--- a/src/server/Server.Domain/Transactions/Transaction.cs
+++ b/src/server/Server.Domain/Transactions/Transaction.cs
@@ -30,6 +30,9 @@ public sealed class Transaction : AggregateRoot<int>
     /// <summary>Free-text notes.</summary>
     public string Notes { get; private set; } = "";
 
+    /// <summary>Whether this transaction represents staked crypto (a staked outflow does not reduce the holding).</summary>
+    public bool IsStaked { get; private set; }
+
     /// <summary>When the transaction record was created.</summary>
     public DateTime CreatedAt { get; private set; }
 
@@ -42,7 +45,8 @@ public sealed class Transaction : AggregateRoot<int>
 
     /// <summary>Creates a new transaction, requiring a valid owning account.</summary>
     public static Transaction Create(int accountId, Symbol symbol, TransactionType type, Quantity quantity,
-                                     double price, double fee, CurrencyCode currency, TradeDate date, string? notes)
+                                     double price, double fee, CurrencyCode currency, TradeDate date, string? notes,
+                                     bool isStaked = false)
     {
         if (accountId <= 0)
             throw new DomainException("A transaction must belong to an account.");
@@ -56,13 +60,14 @@ public sealed class Transaction : AggregateRoot<int>
             Fee = fee,
             Currency = currency,
             Date = date,
-            Notes = notes ?? ""
+            Notes = notes ?? "",
+            IsStaked = isStaked
         };
     }
 
     /// <summary>Updates the transaction's editable fields.</summary>
     public void Update(Symbol symbol, TransactionType type, Quantity quantity, double price, double fee,
-                       CurrencyCode currency, TradeDate date, string? notes)
+                       CurrencyCode currency, TradeDate date, string? notes, bool isStaked = false)
     {
         Symbol = symbol;
         Type = type;
@@ -72,6 +77,7 @@ public sealed class Transaction : AggregateRoot<int>
         Currency = currency;
         Date = date;
         Notes = notes ?? "";
+        IsStaked = isStaked;
     }
 
     /// <summary>Gross traded value = quantity × unit price, in the transaction currency.</summary>

--- a/src/server/Server.Infrastructure/DependencyInjection.cs
+++ b/src/server/Server.Infrastructure/DependencyInjection.cs
@@ -31,6 +31,7 @@ public static class DependencyInjection
         services.AddScoped<IPriceService, PriceService>();
         services.AddScoped<IWealthService, WealthService>();
         services.AddScoped<IImporterService, ImporterService>();
+        services.AddScoped<IDatabaseBackupService, DatabaseBackupService>();
 
         return services;
     }

--- a/src/server/Server.Infrastructure/Persistence/CapitrackDbContext.cs
+++ b/src/server/Server.Infrastructure/Persistence/CapitrackDbContext.cs
@@ -54,6 +54,7 @@ public class CapitrackDbContext(DbContextOptions<CapitrackDbContext> options) : 
             e.Property(x => x.Quantity).HasConversion(v => v.Value, v => Quantity.Create(v));
             e.Property(x => x.Currency).HasConversion(v => v.Value, v => CurrencyCode.Create(v));
             e.Property(x => x.Date).HasConversion(v => v.Value, v => TradeDate.Create(v));
+            e.Property(x => x.IsStaked).HasDefaultValue(false);
             e.Property(x => x.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP").ValueGeneratedOnAdd();
             e.HasIndex(x => x.AccountId);
             e.HasIndex(x => x.Symbol);

--- a/src/server/Server.Infrastructure/Persistence/DatabaseBackupService.cs
+++ b/src/server/Server.Infrastructure/Persistence/DatabaseBackupService.cs
@@ -1,0 +1,148 @@
+using Server.Domain.Accounts;
+using Server.Domain.Currencies;
+using Server.Domain.Goals;
+using Server.Domain.Tags;
+using Server.Domain.Transactions;
+
+namespace Server.Infrastructure.Persistence;
+
+/// <summary>
+/// Exports the full portfolio dataset to a <see cref="DatabaseSnapshot"/> and restores it.
+/// Import is a destructive, transactional full-replace that preserves the user/auth rows and
+/// clears the transient price cache. Primary keys are REMAPPED on import (EF + SQLite make
+/// explicit store-generated-key inserts unreliable), so every account/tag/goal link stays
+/// valid; created_at/updated_at are reset to import time.
+/// </summary>
+public sealed class DatabaseBackupService(CapitrackDbContext db) : IDatabaseBackupService
+{
+    private const int SnapshotVersion = 1;
+
+    /// <inheritdoc />
+    public async Task<DatabaseSnapshot> ExportAsync(CancellationToken ct)
+    {
+        var accounts = await db.Accounts.AsNoTracking().ToListAsync(ct);
+        var transactions = await db.Transactions.AsNoTracking().ToListAsync(ct);
+        var tags = await db.Tags.AsNoTracking().ToListAsync(ct);
+        var goals = await db.Goals.AsNoTracking().ToListAsync(ct);
+        var rates = await db.CurrencyRates.AsNoTracking().ToListAsync(ct);
+        var dailyWealth = await db.DailyWealth.AsNoTracking().ToListAsync(ct);
+
+        var accountTags = (await db.AccountTags.AsNoTracking().ToListAsync(ct))
+            .GroupBy(x => x.AccountId).ToDictionary(g => g.Key, g => g.Select(x => x.TagId).ToList());
+        var transactionTags = (await db.TransactionTags.AsNoTracking().ToListAsync(ct))
+            .GroupBy(x => x.TransactionId).ToDictionary(g => g.Key, g => g.Select(x => x.TagId).ToList());
+        var goalTags = (await db.GoalTags.AsNoTracking().ToListAsync(ct))
+            .GroupBy(x => x.GoalId).ToDictionary(g => g.Key, g => g.Select(x => x.TagId).ToList());
+
+        return new DatabaseSnapshot(
+            SnapshotVersion,
+            DateTime.UtcNow,
+            accounts.Select(a => new SnapshotAccount(
+                a.Id, a.Name, a.Type.Value, a.Currency.Value, a.Description, a.Icon, a.Color.Value,
+                accountTags.GetValueOrDefault(a.Id, []))).ToList(),
+            transactions.Select(t => new SnapshotTransaction(
+                t.Id, t.AccountId, t.Symbol.Value, t.Type.Value, t.Quantity.Value, t.Price, t.Fee,
+                t.Currency.Value, t.Date.Value, t.Notes, transactionTags.GetValueOrDefault(t.Id, []))).ToList(),
+            tags.Select(t => new SnapshotTag(t.Id, t.Name, t.Color.Value)).ToList(),
+            goals.Select(g => new SnapshotGoal(
+                g.Id, g.Title, g.TargetAmount, g.TargetDate.Value, g.Description, g.Achieved, g.CategoryId,
+                goalTags.GetValueOrDefault(g.Id, []))).ToList(),
+            rates.Select(r => new SnapshotCurrencyRate(r.Id, r.FromCurrency.Value, r.ToCurrency.Value, r.Rate)).ToList(),
+            dailyWealth.Select(d => new SnapshotDailyWealth(d.Date, d.TotalWealth, d.TotalCost, d.BaseCurrency, d.Details)).ToList());
+    }
+
+    /// <inheritdoc />
+    public async Task<ImportResult> ImportAsync(DatabaseSnapshot snapshot, CancellationToken ct)
+    {
+        await using var transaction = await db.Database.BeginTransactionAsync(ct);
+        try
+        {
+            // 1. Wipe every portfolio table. Users (auth) are preserved; the price cache is transient.
+            await db.TransactionTags.ExecuteDeleteAsync(ct);
+            await db.GoalTags.ExecuteDeleteAsync(ct);
+            await db.AccountTags.ExecuteDeleteAsync(ct);
+            await db.Transactions.ExecuteDeleteAsync(ct);
+            await db.Goals.ExecuteDeleteAsync(ct);
+            await db.CurrencyRates.ExecuteDeleteAsync(ct);
+            await db.DailyWealth.ExecuteDeleteAsync(ct);
+            await db.Accounts.ExecuteDeleteAsync(ct);
+            await db.Tags.ExecuteDeleteAsync(ct);
+            await db.PriceCache.ExecuteDeleteAsync(ct);
+
+            // 2. Tags first (everything else may reference them).
+            var tagPairs = (snapshot.Tags ?? [])
+                .Select(t => (Src: t, Entity: Tag.Create(t.Name, Color.CreateOrDefault(t.Color))))
+                .ToList();
+            db.Tags.AddRange(tagPairs.Select(p => p.Entity));
+            await db.SaveChangesAsync(ct);
+            var tagMap = tagPairs.ToDictionary(p => p.Src.Id, p => p.Entity.Id);
+
+            // 3. Accounts + their tag links.
+            var accountPairs = (snapshot.Accounts ?? [])
+                .Select(a => (Src: a, Entity: Account.Create(
+                    a.Name, AccountType.From(a.Type), CurrencyCode.Create(a.Currency),
+                    a.Description, a.Icon, Color.CreateOrDefault(a.Color))))
+                .ToList();
+            db.Accounts.AddRange(accountPairs.Select(p => p.Entity));
+            await db.SaveChangesAsync(ct);
+            var accountMap = accountPairs.ToDictionary(p => p.Src.Id, p => p.Entity.Id);
+            foreach (var (src, entity) in accountPairs)
+                AddTagLinks(src.TagIds, tagMap, newTagId => db.AccountTags.Add(new AccountTag { AccountId = entity.Id, TagId = newTagId }));
+
+            // 4. Goals + their tag links (categories are unused, so category_id is dropped).
+            var goalPairs = (snapshot.Goals ?? [])
+                .Select(g => (Src: g, Entity: Goal.Create(
+                    g.Title, g.TargetAmount, TradeDate.Create(g.TargetDate), g.Description, g.Achieved, null)))
+                .ToList();
+            db.Goals.AddRange(goalPairs.Select(p => p.Entity));
+            await db.SaveChangesAsync(ct);
+            foreach (var (src, entity) in goalPairs)
+                AddTagLinks(src.TagIds, tagMap, newTagId => db.GoalTags.Add(new GoalTag { GoalId = entity.Id, TagId = newTagId }));
+
+            // 5. Transactions (account ids remapped; orphans skipped) + their tag links.
+            var transactionPairs = (snapshot.Transactions ?? [])
+                .Where(t => accountMap.ContainsKey(t.AccountId))
+                .Select(t => (Src: t, Entity: Transaction.Create(
+                    accountMap[t.AccountId], Symbol.Create(t.Symbol), TransactionType.From(t.Type),
+                    Quantity.Create(t.Quantity), t.Price, t.Fee, CurrencyCode.Create(t.Currency),
+                    TradeDate.Create(t.Date), t.Notes)))
+                .ToList();
+            db.Transactions.AddRange(transactionPairs.Select(p => p.Entity));
+            await db.SaveChangesAsync(ct);
+            foreach (var (src, entity) in transactionPairs)
+                AddTagLinks(src.TagIds, tagMap, newTagId => db.TransactionTags.Add(new TransactionTag { TransactionId = entity.Id, TagId = newTagId }));
+
+            // 6. Currency rates + daily wealth snapshots (no foreign keys).
+            db.CurrencyRates.AddRange((snapshot.CurrencyRates ?? [])
+                .Select(r => CurrencyRate.Create(CurrencyCode.Create(r.FromCurrency), CurrencyCode.Create(r.ToCurrency), r.Rate)));
+            db.DailyWealth.AddRange((snapshot.DailyWealth ?? [])
+                .Select(d => new DailyWealthRecord
+                {
+                    Date = d.Date, TotalWealth = d.Total, TotalCost = d.TotalCost,
+                    BaseCurrency = d.BaseCurrency, Details = string.IsNullOrEmpty(d.Details) ? "{}" : d.Details
+                }));
+            await db.SaveChangesAsync(ct);
+
+            await transaction.CommitAsync(ct);
+
+            var rateCount = snapshot.CurrencyRates?.Count ?? 0;
+            var wealthCount = snapshot.DailyWealth?.Count ?? 0;
+            var message = $"Replaced all data: {accountMap.Count} accounts, {transactionPairs.Count} transactions, " +
+                          $"{tagMap.Count} tags, {goalPairs.Count} goals, {rateCount} currency rates.";
+            return new ImportResult(accountMap.Count, transactionPairs.Count, tagMap.Count, goalPairs.Count, rateCount, wealthCount, message);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(ct);
+            throw;
+        }
+    }
+
+    /// <summary>Adds a join-table row for each known tag id, skipping ids absent from the import.</summary>
+    private static void AddTagLinks(List<int>? tagIds, IReadOnlyDictionary<int, int> tagMap, Action<int> add)
+    {
+        foreach (var oldTagId in tagIds ?? [])
+            if (tagMap.TryGetValue(oldTagId, out var newTagId))
+                add(newTagId);
+    }
+}

--- a/src/server/Server.Infrastructure/Persistence/Repositories/TransactionRepository.cs
+++ b/src/server/Server.Infrastructure/Persistence/Repositories/TransactionRepository.cs
@@ -4,19 +4,61 @@ namespace Server.Infrastructure.Persistence.Repositories;
 
 public sealed class TransactionRepository(CapitrackDbContext db) : ITransactionRepository
 {
-    public async Task<IReadOnlyList<Transaction>> ListAsync(int? accountId, string? symbol, int? limit, int? offset, CancellationToken ct = default)
+    public async Task<IReadOnlyList<Transaction>> ListAsync(int? accountId, string? symbol, string? search, string? type, int? limit, int? offset, CancellationToken ct = default)
     {
-        var q = db.Transactions.AsQueryable();
+        IQueryable<Transaction> q = ApplyFilters(db.Transactions.AsQueryable(), accountId, symbol, type)
+            .OrderByDescending(t => t.Date).ThenByDescending(t => t.Id);
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            // A CONTAINS on the symbol can't be translated through the value-object
+            // converter, so the search term is applied in memory — consistently with
+            // CountAsync, so the page and its total always agree.
+            var needle = search.Trim();
+            IEnumerable<Transaction> matches = (await q.ToListAsync(ct))
+                .Where(t => t.Symbol.Value.Contains(needle, StringComparison.OrdinalIgnoreCase));
+            if (offset is > 0) matches = matches.Skip(offset.Value);
+            if (limit is > 0) matches = matches.Take(limit.Value);
+            return matches.ToList();
+        }
+
+        if (offset is > 0) q = q.Skip(offset.Value);
+        if (limit is > 0) q = q.Take(limit.Value);
+        return await q.ToListAsync(ct);
+    }
+
+    public async Task<int> CountAsync(int? accountId, string? symbol, string? search, string? type, CancellationToken ct = default)
+    {
+        var q = ApplyFilters(db.Transactions.AsQueryable(), accountId, symbol, type);
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var needle = search.Trim();
+            return (await q.ToListAsync(ct))
+                .Count(t => t.Symbol.Value.Contains(needle, StringComparison.OrdinalIgnoreCase));
+        }
+        return await q.CountAsync(ct);
+    }
+
+    /// <summary>
+    /// Applies the SQL-translatable account/exact-symbol/type filters shared by
+    /// <see cref="ListAsync"/> and <see cref="CountAsync"/>. The free-text symbol
+    /// <c>search</c> (CONTAINS) is applied in memory by the callers.
+    /// </summary>
+    private static IQueryable<Transaction> ApplyFilters(IQueryable<Transaction> q, int? accountId, string? symbol, string? type)
+    {
         if (accountId.HasValue) q = q.Where(t => t.AccountId == accountId.Value);
         if (!string.IsNullOrWhiteSpace(symbol))
         {
             var s = Symbol.Create(symbol);
             q = q.Where(t => t.Symbol == s);
         }
-        q = q.OrderByDescending(t => t.Date).ThenByDescending(t => t.Id);
-        if (offset is > 0) q = q.Skip(offset.Value);
-        if (limit is > 0) q = q.Take(limit.Value);
-        return await q.ToListAsync(ct);
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            // Exact match on the persisted TransactionType string (e.g. "buy").
+            var t = TransactionType.From(type);
+            q = q.Where(x => x.Type == t);
+        }
+        return q;
     }
 
     public async Task<IReadOnlyList<Transaction>> ForAccountAsync(int accountId, CancellationToken ct = default) =>

--- a/src/server/Server.Infrastructure/Services/ImporterService.cs
+++ b/src/server/Server.Infrastructure/Services/ImporterService.cs
@@ -77,11 +77,13 @@ public sealed partial class ImporterService(CapitrackDbContext db) : IImporterSe
         return set;
     }
 
-    // ---- Main import ----
-    public async Task<ImportResultDto> ImportAsync(string content, int accountId, string? formatHint)
+    private static readonly string[] KnownFormats = ["revolut-stocks", "revolut-commodities", "trezor", "generic"];
+
+    // ---- Shared parse (format detection + parser dispatch) ----
+    private static (string Format, List<ImportedTransaction> Parsed, List<string> Headers) ParseContent(string content, string? formatHint)
     {
         var (records, headers) = ParseCsv(content);
-        if (records.Count == 0) return new ImportResultDto(0, 0, 0, [], "unknown");
+        if (records.Count == 0) return ("unknown", [], headers);
 
         var format = !string.IsNullOrEmpty(formatHint) ? formatHint : DetectFormat(headers);
         List<ImportedTransaction> parsed = format switch
@@ -92,7 +94,17 @@ public sealed partial class ImporterService(CapitrackDbContext db) : IImporterSe
             "generic" => ParseGeneric(records),
             _ => []
         };
-        if (format is not ("revolut-stocks" or "revolut-commodities" or "trezor" or "generic"))
+        return (format, parsed, headers);
+    }
+
+    // ---- Main import ----
+    public async Task<ImportResultDto> ImportAsync(string content, int accountId, string? formatHint)
+    {
+        var (records, _) = ParseCsv(content);
+        if (records.Count == 0) return new ImportResultDto(0, 0, 0, [], "unknown");
+
+        var (format, parsed, headers) = ParseContent(content, formatHint);
+        if (!KnownFormats.Contains(format))
             return new ImportResultDto(0, 0, records.Count, [$"Unknown CSV format. Headers: {string.Join(", ", headers)}"], "unknown");
 
         var existing = await ExistingFingerprintsAsync(accountId);
@@ -122,6 +134,64 @@ public sealed partial class ImporterService(CapitrackDbContext db) : IImporterSe
         }
         await db.SaveChangesAsync();
         return new ImportResultDto(imported, skipped, parsed.Count, errors, format);
+    }
+
+    // ---- Preview (parse only, no insert) ----
+    public async Task<PreviewFileDto> PreviewAsync(string fileName, string content, int accountId)
+    {
+        var (format, parsed, _) = ParseContent(content, null);
+        var existing = await ExistingFingerprintsAsync(accountId);
+
+        var account = await db.Accounts.FindAsync(accountId);
+        bool accountIsCrypto = account?.Type.Value is "crypto";
+
+        var rows = new List<PreviewTransactionDto>(parsed.Count);
+        for (var i = 0; i < parsed.Count; i++)
+        {
+            var tx = parsed[i];
+            var fp = Fingerprint(accountId, tx.Symbol, tx.Type, tx.Quantity, tx.Price, tx.Date);
+            bool symbolIsCrypto = tx.Symbol.EndsWith("-USD", StringComparison.OrdinalIgnoreCase);
+            bool canStake = tx.Type == "transfer_out" && (symbolIsCrypto || accountIsCrypto);
+
+            rows.Add(new PreviewTransactionDto(
+                i, tx.Symbol, tx.Type, tx.Quantity, tx.Price, tx.Fee,
+                tx.Currency, tx.Date, tx.Notes, existing.Contains(fp), canStake));
+        }
+        return new PreviewFileDto(fileName, format, rows);
+    }
+
+    // ---- Import a user-selected set (no CSV parsing) ----
+    public async Task<ImportResultDto> ImportSelectedAsync(int accountId, IEnumerable<SelectedTransactionDto> transactions)
+    {
+        var list = transactions as IReadOnlyList<SelectedTransactionDto> ?? transactions.ToList();
+        var existing = await ExistingFingerprintsAsync(accountId);
+        int imported = 0, skipped = 0;
+        var errors = new List<string>();
+        for (var i = 0; i < list.Count; i++)
+        {
+            var tx = list[i];
+            try
+            {
+                var fp = Fingerprint(accountId, tx.Symbol, tx.Type, tx.Quantity, tx.Price, tx.Date);
+                if (existing.Contains(fp)) { skipped++; continue; }
+                db.Transactions.Add(Transaction.Create(
+                    accountId,
+                    Symbol.Create(tx.Symbol),
+                    TransactionType.From(tx.Type),
+                    Quantity.Create(tx.Quantity),
+                    tx.Price,
+                    tx.Fee,
+                    CurrencyCode.Create(tx.Currency),
+                    TradeDate.Create(tx.Date),
+                    tx.Notes,
+                    isStaked: tx.IsStaked));
+                existing.Add(fp);
+                imported++;
+            }
+            catch (Exception e) { errors.Add($"Row {i + 1}: {e.Message}"); }
+        }
+        await db.SaveChangesAsync();
+        return new ImportResultDto(imported, skipped, list.Count, errors, "selected");
     }
 
     // ---- Parsers ----

--- a/src/server/Server.Infrastructure/Services/WealthService.cs
+++ b/src/server/Server.Infrastructure/Services/WealthService.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using System.Text.Json;
+using Server.Domain.Accounts;
 using Server.Domain.Holdings;
+using Server.Domain.Transactions;
 using Server.Infrastructure.Persistence;
 
 namespace Server.Infrastructure.Services;
@@ -34,7 +36,10 @@ public sealed class WealthService(CapitrackDbContext db, IPriceService prices, I
     {
         var txs = await db.Transactions.ToListAsync();
         var accounts = await db.Accounts.ToDictionaryAsync(a => a.Id);
-        var holdings = HoldingsCalculator.ByAccount(txs);
+
+        // Cash/savings accounts are valued at their cash balance, never via a market quote,
+        // so their currency "symbol" must never reach Yahoo: feed only non-cash txs to the calculator.
+        var holdings = HoldingsCalculator.ByAccount(txs.Where(t => !IsCashAccount(accounts, t.AccountId)));
 
         var symbols = holdings.Select(h => h.Symbol.Value).Distinct().ToList();
         var priceMap = new Dictionary<string, QuoteDto>();
@@ -71,12 +76,56 @@ public sealed class WealthService(CapitrackDbContext db, IPriceService prices, I
             totalCost += costBasis;
         }
 
+        // Cash/savings accounts: market value = balance × FX(accountCurrency→base); cost basis == market value (no gain).
+        foreach (var cash in CashBalances(txs, accounts, baseCurrency, rates))
+        {
+            if (!perAccount.TryGetValue(cash.AccountId, out var acc))
+                perAccount[cash.AccountId] = acc = new AccountAccum { AccountId = cash.AccountId, AccountName = cash.AccountName };
+            acc.MarketValue += cash.Value;
+            acc.CostBasis += cash.Value;
+            totalWealth += cash.Value;
+            totalCost += cash.Value;
+        }
+
         return new DashboardSummaryDto(
             totalWealth, totalCost, totalWealth - totalCost,
             totalCost > 0 ? (totalWealth - totalCost) / totalCost * 100 : 0,
             baseCurrency,
             perAccount.Values.Select(a => new AccountSummaryDto(a.AccountId, a.AccountName, a.MarketValue, a.CostBasis, a.HoldingsCount)).ToList(),
             holdings.Count);
+    }
+
+    private static bool IsCashAccount(IReadOnlyDictionary<int, Account> accounts, int accountId) =>
+        accounts.TryGetValue(accountId, out var a) && a.Type.IsCash;
+
+    private readonly record struct CashAccountValue(int AccountId, string AccountName, double Value);
+
+    /// <summary>
+    /// Values each cash/savings account at balance × FX(accountCurrency→base).
+    /// Balance = Σ (IncreasesQuantity ? +qty*price : DecreasesQuantity ? -qty*price : 0) over the account's transactions.
+    /// Accounts with no transactions are skipped.
+    /// </summary>
+    private static IEnumerable<CashAccountValue> CashBalances(
+        IEnumerable<Transaction> txs,
+        IReadOnlyDictionary<int, Account> accounts,
+        string baseCurrency,
+        IReadOnlyDictionary<string, double> rates)
+    {
+        foreach (var g in txs.Where(t => IsCashAccount(accounts, t.AccountId)).GroupBy(t => t.AccountId))
+        {
+            var account = accounts.GetValueOrDefault(g.Key);
+            double balance = g.Sum(t =>
+                t.Type.IncreasesQuantity ? t.Quantity.Value * t.Price
+                : t.Type.DecreasesQuantity ? -(t.Quantity.Value * t.Price)
+                : 0);
+
+            double value = balance;
+            var accountCurrency = account?.Currency.Value ?? "";
+            if (!string.IsNullOrEmpty(accountCurrency) && accountCurrency != baseCurrency)
+                value *= rates.GetValueOrDefault($"{accountCurrency}_{baseCurrency}", 1);
+
+            yield return new CashAccountValue(g.Key, account?.Name ?? "", value);
+        }
     }
 
     private class AccountAccum
@@ -109,7 +158,7 @@ public sealed class WealthService(CapitrackDbContext db, IPriceService prices, I
         {
             holdingMap.TryAdd(tx.Symbol.Value, 0);
             if (tx.Type.CountsAsHistoryAdd) holdingMap[tx.Symbol.Value] += tx.Quantity.Value;
-            else if (tx.Type.CountsAsHistorySub) holdingMap[tx.Symbol.Value] -= tx.Quantity.Value;
+            else if (tx.Type.CountsAsHistorySub && !tx.IsStaked) holdingMap[tx.Symbol.Value] -= tx.Quantity.Value;
         }
         var activeSymbols = holdingMap.Where(kv => kv.Value > 0.00000001).Select(kv => kv.Key).ToList();
         if (activeSymbols.Count == 0) return [];
@@ -152,7 +201,7 @@ public sealed class WealthService(CapitrackDbContext db, IPriceService prices, I
                 var tx = transactions[txIndex];
                 running.TryAdd(tx.Symbol.Value, 0);
                 if (tx.Type.CountsAsHistoryAdd) running[tx.Symbol.Value] += tx.Quantity.Value;
-                else if (tx.Type.CountsAsHistorySub) running[tx.Symbol.Value] -= tx.Quantity.Value;
+                else if (tx.Type.CountsAsHistorySub && !tx.IsStaked) running[tx.Symbol.Value] -= tx.Quantity.Value;
                 txIndex++;
             }
 
@@ -191,7 +240,9 @@ public sealed class WealthService(CapitrackDbContext db, IPriceService prices, I
         var today = Today();
         var txs = await db.Transactions.ToListAsync();
         var accounts = await db.Accounts.ToDictionaryAsync(a => a.Id);
-        var holdings = HoldingsCalculator.ByAccount(txs);
+
+        // Exclude cash/savings accounts from market-holding maths (valued at balance below).
+        var holdings = HoldingsCalculator.ByAccount(txs.Where(t => !IsCashAccount(accounts, t.AccountId)));
 
         var priceMap = new Dictionary<string, QuoteDto>();
         foreach (var s in holdings.Select(h => h.Symbol.Value).Distinct())
@@ -224,6 +275,17 @@ public sealed class WealthService(CapitrackDbContext db, IPriceService prices, I
             acc.CostBasis += costBasis;
             totalWealth += marketValue;
             totalCost += costBasis;
+        }
+
+        // Cash/savings accounts: valued at balance × FX(accountCurrency→base); cost basis == market value (no gain).
+        foreach (var cash in CashBalances(txs, accounts, baseCurrency, rates))
+        {
+            if (!details.TryGetValue(cash.AccountId, out var acc))
+                details[cash.AccountId] = acc = new AccountAccum { AccountId = cash.AccountId, AccountName = cash.AccountName };
+            acc.MarketValue += cash.Value;
+            acc.CostBasis += cash.Value;
+            totalWealth += cash.Value;
+            totalCost += cash.Value;
         }
 
         var detailsJson = JsonSerializer.Serialize(new


### PR DESCRIPTION
## Overview

This PR adds the requested account/import features, on top of the previously-unmerged Settings tooling. Two commits for easy review:

1. **`456edf8` — settings baseline** (already smoke-tested): DB JSON export/import, market-data providers panel, Activity server-side pagination, in-app confirm dialog, capitrack.dev/docs links.
2. **`9d8b9a6` — these features** (below).

## New features

### 1 · Bulk CSV import
Import **multiple CSV files into one account in a single action** via `POST /api/transactions/import/csv/bulk` (fingerprint dedup runs across all files). The import modal now accepts multiple files.

### 2 · "Check & Import" with transaction selection
A new **Check & Import** button parses the file(s) **without saving** (`POST /api/transactions/import/preview`) and opens a modal that lists every parsed row with a **checkbox** — so you import only what you pick. Multiple files → **one tab per file**. Each row is flagged `is_duplicate` (duplicates pre-unchecked) and `can_stake` (crypto outflows). Selected rows import via `POST /api/transactions/import/selected`.

### 3 · Savings (cash) account type
A `savings`/`cash` account holds plain cash in one currency — **no symbol, no Yahoo chart**. `WealthService` values it at **balance × FX** with zero market gain (cash is excluded from the holdings/quote path). The account page shows a **cash layout**: balance hero, a client-side **cash-flow chart**, Total in/out, a movements table, and an **Add cash** (deposit/withdrawal) form.

### 5 · Crypto staking flag
`Transaction.IsStaked`. A **staked `transfer_out`** (e.g. a Trezor `SENT` that's really staking ETH) **keeps its quantity in the holding** — `HoldingsCalculator` and the portfolio-history replay exclude staked outflows from the decrease — so staked crypto **still counts toward total wealth**. Settable per-row in Check & Import and via a toggle when editing any transaction.

## Verification (against the real Trezor + Revolut exports — feature #4)

| Check | Result |
|---|---|
| Full solution build | **0 errors** |
| Server.Tests / Client.Tests | **54/54** · **14/14** |
| Check & Import preview (Ethereum Trezor) | 11 rows, format `trezor`, **2 `can_stake`** SENT rows |
| Staked 0.5 ETH `transfer_out` | holding stayed **0.81878279** (didn't drop) — still in wealth |
| Bulk import (Bitcoin+Solana+Cardano, 1 call) | imported **39**, format `bulk` |
| Savings account (1000 in − 200 out) | dashboard **market_value 800**, gain 0, no Yahoo |
| Revolut stocks statement | imported **130** txns → live-priced holdings |

All verified through `docker compose` with the images rebuilt from this branch.

## Notes
- New API: `POST /import/csv/bulk`, `POST /import/preview`, `POST /import/selected`; `is_staked` on transaction create/update + DTO. Existing `import/csv` and `import/detect` are unchanged.
- DB migration-free (EnsureCreated); `IsStaked` defaults to `false` so existing rows are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)