### PR TITLE
feat(security): 2FA, login-attempt audit, IP blacklist + brute-force lockout

### DIFF
--- a/src/client/Client.Application/IApiClient.cs
+++ b/src/client/Client.Application/IApiClient.cs
@@ -19,6 +19,8 @@ public interface IApiClient
 
     Task<(bool ok, T? value)> PostWithStatusAsync<T>(string url, object body, JsonSerializerOptions? opts = null);
 
+    Task<(bool ok, int status, T? value)> PostWithFullStatusAsync<T>(string url, object body, JsonSerializerOptions? opts = null);
+
     Task<T?> PutAsync<T>(string url, object body, JsonSerializerOptions? opts = null);
 
     Task<(bool ok, T? value)> PutWithStatusAsync<T>(string url, object body, JsonSerializerOptions? opts = null);

--- a/src/client/Client.Application/Models/BlacklistedIpDto.cs
+++ b/src/client/Client.Application/Models/BlacklistedIpDto.cs
@@ -1,0 +1,14 @@
+namespace Client.Application.Models;
+
+/// <summary>An IP address blocked from signing in — either auto-blocked after
+/// repeated failures or added manually. A null <see cref="ExpiresAt"/> means the
+/// block is permanent.</summary>
+public class BlacklistedIpDto
+{
+    public int Id { get; set; }
+    public string IpAddress { get; set; } = "";
+    public string? Username { get; set; }
+    public string Reason { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+}

--- a/src/client/Client.Application/Models/LoginAttemptDto.cs
+++ b/src/client/Client.Application/Models/LoginAttemptDto.cs
@@ -1,0 +1,14 @@
+namespace Client.Application.Models;
+
+/// <summary>A single recorded sign-in attempt (success or failure) shown in the
+/// Login Security panel.</summary>
+public class LoginAttemptDto
+{
+    public int Id { get; set; }
+    public string Username { get; set; } = "";
+    public string IpAddress { get; set; } = "";
+    public bool Success { get; set; }
+    public string Reason { get; set; } = "";
+    public DateTime CreatedAt { get; set; }
+    public string? UserAgent { get; set; }
+}

--- a/src/client/Client.Application/Models/SessionDto.cs
+++ b/src/client/Client.Application/Models/SessionDto.cs
@@ -1,8 +1,9 @@
 namespace Client.Application.Models;
 
-/// <summary>The authenticated user's session info (username and base currency).</summary>
+/// <summary>The authenticated user's session info (username, base currency and 2FA state).</summary>
 public class SessionDto
 {
     public string Username { get; set; } = "";
     public string BaseCurrency { get; set; } = "EUR";
+    public bool TwoFactorEnabled { get; set; }
 }

--- a/src/client/Client.Application/Models/TwoFactorSetupDto.cs
+++ b/src/client/Client.Application/Models/TwoFactorSetupDto.cs
@@ -1,0 +1,16 @@
+namespace Client.Application.Models;
+
+/// <summary>The provisioning payload returned when enrolling in two-factor auth
+/// (POST /api/auth/2fa/setup): the shared secret, the otpauth:// URI and a
+/// ready-to-render QR-code SVG.</summary>
+public class TwoFactorSetupDto
+{
+    /// <summary>The base32 TOTP shared secret (for manual entry).</summary>
+    public string Secret { get; set; } = "";
+
+    /// <summary>The otpauth:// provisioning URI encoded by the QR code.</summary>
+    public string OtpauthUri { get; set; } = "";
+
+    /// <summary>A complete &lt;svg&gt;…&lt;/svg&gt; string rendering the QR code.</summary>
+    public string QrSvg { get; set; } = "";
+}

--- a/src/client/Client.Infrastructure/Services/ApiClient.cs
+++ b/src/client/Client.Infrastructure/Services/ApiClient.cs
@@ -74,6 +74,19 @@ public class ApiClient(HttpClient http) : IApiClient
         return (r.IsSuccessStatusCode, value);
     }
 
+    /// <summary>
+    /// Like <see cref="PostWithStatusAsync{T}"/> but also surfaces the numeric HTTP
+    /// status code, so callers can distinguish e.g. 401 (bad credentials) from 429
+    /// (rate-limited / locked out).
+    /// </summary>
+    public async Task<(bool ok, int status, T? value)> PostWithFullStatusAsync<T>(string url, object body, JsonSerializerOptions? opts = null)
+    {
+        var r = await http.PostAsJsonAsync(url, body, opts ?? Json);
+        if (r.StatusCode == HttpStatusCode.Unauthorized && !url.Contains("/auth/")) Unauthorized?.Invoke();
+        var value = await r.Content.ReadFromJsonAsync<T>(Json);
+        return (r.IsSuccessStatusCode, (int)r.StatusCode, value);
+    }
+
     public async Task<T?> PutAsync<T>(string url, object body, JsonSerializerOptions? opts = null)
     {
         var r = await http.PutAsJsonAsync(url, body, opts ?? Json);

--- a/src/client/Client.Presentation/Pages/Login.razor
+++ b/src/client/Client.Presentation/Pages/Login.razor
@@ -33,34 +33,73 @@
         </div>
 
         <div style="padding:46px 40px;display:flex;flex-direction:column;justify-content:center;">
-            <h1 style="font-size:1.5rem;font-weight:800;letter-spacing:-0.02em;">Welcome back</h1>
-            <p class="sub" style="margin-top:4px;">Sign in to your Capitrack instance</p>
-            <form @onsubmit="DoLogin" @onsubmit:preventDefault style="margin-top:26px;display:flex;flex-direction:column;gap:16px;">
-                <div class="field">
-                    <label>Username</label>
-                    <div style="position:relative;">
-                        <span style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-4);"><Icon Name="user" Width="17" Height="17" /></span>
-                        <input class="input" style="padding-left:38px;" @bind="_username" @bind:event="oninput" placeholder="Enter username" autocomplete="username" />
+            @if (_step == "credentials")
+            {
+                <h1 style="font-size:1.5rem;font-weight:800;letter-spacing:-0.02em;">Welcome back</h1>
+                <p class="sub" style="margin-top:4px;">Sign in to your Capitrack instance</p>
+                <form @onsubmit="DoLogin" @onsubmit:preventDefault style="margin-top:26px;display:flex;flex-direction:column;gap:16px;">
+                    <div class="field">
+                        <label>Username</label>
+                        <div style="position:relative;">
+                            <span style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-4);"><Icon Name="user" Width="17" Height="17" /></span>
+                            <input class="input" style="padding-left:38px;" @bind="_username" @bind:event="oninput" placeholder="Enter username" autocomplete="username" />
+                        </div>
                     </div>
-                </div>
-                <div class="field">
-                    <label>Password</label>
-                    <div style="position:relative;">
-                        <span style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-4);"><Icon Name="lock" Width="17" Height="17" /></span>
-                        <input class="input" style="padding-left:38px;" type="password" @bind="_password" @bind:event="oninput" placeholder="Enter password" autocomplete="current-password" />
+                    <div class="field">
+                        <label>Password</label>
+                        <div style="position:relative;">
+                            <span style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-4);"><Icon Name="lock" Width="17" Height="17" /></span>
+                            <input class="input" style="padding-left:38px;" type="password" @bind="_password" @bind:event="oninput" placeholder="Enter password" autocomplete="current-password" />
+                        </div>
                     </div>
+                    <button class="btn btn-pri" type="submit" style="height:44px;margin-top:4px;" disabled="@_busy">
+                        <Icon Name="logout" Style="transform:scaleX(-1);" /> Sign In
+                    </button>
+                    @if (_lockout is not null)
+                    {
+                        <div style="padding:11px 13px;border-radius:var(--r-sm);background:var(--down-soft);border:1px solid var(--down);color:var(--down);font-size:0.85rem;font-weight:600;display:flex;gap:8px;align-items:center;">
+                            <Icon Name="shield" Width="16" Height="16" /> <span>@_lockout</span>
+                        </div>
+                    }
+                    else if (_error is not null)
+                    {
+                        <div class="error-message">@_error</div>
+                    }
+                </form>
+                <div style="margin-top:20px;padding:10px 12px;border-radius:var(--r-sm);background:var(--surface-2);border:1px solid var(--border);font-size:0.8rem;color:var(--text-3);display:flex;gap:8px;align-items:center;">
+                    <Icon Name="info" Width="15" Height="15" /> <span>First run? The admin password is printed in the server logs (<code>docker compose logs api</code>).</span>
                 </div>
-                <button class="btn btn-pri" type="submit" style="height:44px;margin-top:4px;">
-                    <Icon Name="logout" Style="transform:scaleX(-1);" /> Sign In
+            }
+            else
+            {
+                <h1 style="font-size:1.5rem;font-weight:800;letter-spacing:-0.02em;">Two-factor authentication</h1>
+                <p class="sub" style="margin-top:4px;">Enter the 6-digit code from your authenticator app</p>
+                <form @onsubmit="VerifyCode" @onsubmit:preventDefault style="margin-top:26px;display:flex;flex-direction:column;gap:16px;">
+                    <div class="field">
+                        <label>Authentication code</label>
+                        <div style="position:relative;">
+                            <span style="position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--text-4);"><Icon Name="shield" Width="17" Height="17" /></span>
+                            <input class="input" style="padding-left:38px;letter-spacing:0.3em;font-size:1.05rem;" @bind="_code" @bind:event="oninput" placeholder="000000" maxlength="6" autocomplete="one-time-code" inputmode="numeric" />
+                        </div>
+                    </div>
+                    <button class="btn btn-pri" type="submit" style="height:44px;margin-top:4px;" disabled="@_busy">
+                        <Icon Name="check" /> Verify
+                    </button>
+                    @if (_lockout is not null)
+                    {
+                        <div style="padding:11px 13px;border-radius:var(--r-sm);background:var(--down-soft);border:1px solid var(--down);color:var(--down);font-size:0.85rem;font-weight:600;display:flex;gap:8px;align-items:center;">
+                            <Icon Name="shield" Width="16" Height="16" /> <span>@_lockout</span>
+                        </div>
+                    }
+                    else if (_error is not null)
+                    {
+                        <div class="error-message">@_error</div>
+                    }
+                </form>
+                <button class="btn btn-ghost btn-sm" style="align-self:flex-start;margin-top:18px;" @onclick="BackToCredentials">
+                    <Icon Name="arrowL" /> Back
                 </button>
-                @if (_error is not null)
-                {
-                    <div class="error-message">@_error</div>
-                }
-            </form>
-            <div style="margin-top:20px;padding:10px 12px;border-radius:var(--r-sm);background:var(--surface-2);border:1px solid var(--border);font-size:0.8rem;color:var(--text-3);display:flex;gap:8px;align-items:center;">
-                <Icon Name="info" Width="15" Height="15" /> <span>First run? The admin password is printed in the server logs (<code>docker compose logs api</code>).</span>
-            </div>
+            }
         </div>
     </div>
 </div>
@@ -75,32 +114,100 @@
 
     private string _username = "admin";
     private string _password = "";
+    private string _code = "";
+    private string _step = "credentials"; // "credentials" | "twofactor"
     private string? _error;
+    private string? _lockout;
+    private bool _busy;
 
     private async Task DoLogin()
     {
         _error = null;
+        _lockout = null;
+        _busy = true;
         try
         {
-            var (ok, json) = await Api.PostWithStatusAsync<JsonElement>("/api/auth/login",
+            var (ok, status, json) = await Api.PostWithFullStatusAsync<JsonElement>("/api/auth/login",
                 new { username = _username, password = _password });
             if (ok)
             {
-                Dispatcher.Dispatch(new SetUserAction(new SessionDto
+                var required = json.TryGetProperty("two_factor_required", out var r) && r.ValueKind == JsonValueKind.True;
+                if (required)
                 {
-                    Username = json.GetProperty("username").GetString() ?? "",
-                    BaseCurrency = json.TryGetProperty("base_currency", out var bc) ? bc.GetString() ?? "EUR" : "EUR"
-                }));
+                    _code = "";
+                    _step = "twofactor";
+                }
+                else
+                {
+                    ApplySession(json);
+                }
+            }
+            else if (status == 429)
+            {
+                _lockout = ReadError(json) ?? "Too many attempts. Please try again later.";
             }
             else
             {
-                _error = json.TryGetProperty("error", out var e) ? e.GetString() : "Login failed";
+                _error = ReadError(json) ?? "Login failed";
             }
         }
         catch
         {
             _error = "Connection error";
         }
+        finally { _busy = false; }
+    }
+
+    private async Task VerifyCode()
+    {
+        _error = null;
+        _lockout = null;
+        _busy = true;
+        try
+        {
+            var (ok, status, json) = await Api.PostWithFullStatusAsync<JsonElement>("/api/auth/login/2fa",
+                new { username = _username, password = _password, code = _code });
+            if (ok)
+            {
+                ApplySession(json);
+            }
+            else if (status == 429)
+            {
+                _lockout = ReadError(json) ?? "Too many attempts. Please try again later.";
+            }
+            else
+            {
+                _error = ReadError(json) ?? "Invalid code";
+            }
+        }
+        catch
+        {
+            _error = "Connection error";
+        }
+        finally { _busy = false; }
+    }
+
+    private void ApplySession(JsonElement json)
+    {
+        if (!json.TryGetProperty("session", out var session) || session.ValueKind != JsonValueKind.Object)
+            return;
+        Dispatcher.Dispatch(new SetUserAction(new SessionDto
+        {
+            Username = session.TryGetProperty("username", out var u) ? u.GetString() ?? "" : "",
+            BaseCurrency = session.TryGetProperty("base_currency", out var bc) ? bc.GetString() ?? "EUR" : "EUR",
+            TwoFactorEnabled = session.TryGetProperty("two_factor_enabled", out var tf) && tf.ValueKind == JsonValueKind.True
+        }));
+    }
+
+    private static string? ReadError(JsonElement json)
+        => json.ValueKind == JsonValueKind.Object && json.TryGetProperty("error", out var e) ? e.GetString() : null;
+
+    private void BackToCredentials()
+    {
+        _step = "credentials";
+        _code = "";
+        _error = null;
+        _lockout = null;
     }
 
     private void ToggleTheme() => Dispatcher.Dispatch(new ToggleThemeAction());

--- a/src/client/Client.Presentation/Pages/Settings.razor
+++ b/src/client/Client.Presentation/Pages/Settings.razor
@@ -235,6 +235,178 @@
                             <p class="sub" style="@(_pwOk ? "color:var(--up);" : "color:var(--down);")">@_pwMsg</p>
                         }
                     </form>
+
+                    <div style="height:1px;background:var(--border);margin:24px 0;"></div>
+
+                    <div style="font-weight:600;font-size:0.92rem;margin-bottom:4px;">Two-factor authentication</div>
+                    <p class="sub" style="margin-bottom:14px;line-height:1.6;">Require a 6-digit code from an authenticator app in addition to your password when signing in.</p>
+
+                    @if (_twoFactorEnabled && _setup is null)
+                    {
+                        <SettingsRow Title="Authenticator app" Sub="A time-based one-time code is required at sign-in.">
+                            <span class="chip up"><Icon Name="check" Width="12" Height="12" /> 2FA is enabled</span>
+                            <button class="btn btn-danger btn-sm" @onclick="DisableTwoFactor"><Icon Name="x" /> Disable 2FA</button>
+                        </SettingsRow>
+                    }
+                    else if (_setup is not null)
+                    {
+                        <div class="card card-pad" style="max-width:460px;">
+                            <p class="sub" style="margin-bottom:14px;line-height:1.6;">Scan this QR code with your authenticator app (Google Authenticator, Authy, 1Password…), or enter the secret manually. Then type the current 6-digit code to finish.</p>
+                            <div style="display:flex;justify-content:center;margin-bottom:16px;">
+                                <div style="background:#fff;border-radius:var(--r-sm);padding:12px;width:180px;height:180px;display:grid;place-items:center;">
+                                    @((MarkupString)_setup.QrSvg)
+                                </div>
+                            </div>
+                            <div class="field" style="margin-bottom:14px;">
+                                <label>Secret (manual entry)</label>
+                                <code style="display:block;padding:9px 12px;background:var(--surface-2);border:1px solid var(--border);border-radius:var(--r-sm);font-size:0.85rem;word-break:break-all;">@_setup.Secret</code>
+                            </div>
+                            <div class="field" style="margin-bottom:14px;">
+                                <label>Verification code</label>
+                                <input class="input" style="letter-spacing:0.3em;" @bind="_setupCode" @bind:event="oninput" placeholder="000000" maxlength="6" autocomplete="one-time-code" inputmode="numeric" />
+                            </div>
+                            @if (_setupMsg is not null)
+                            {
+                                <p class="sub" style="color:var(--down);margin-bottom:12px;">@_setupMsg</p>
+                            }
+                            <div class="flex gap-2">
+                                <button class="btn btn-pri btn-sm" @onclick="ConfirmTwoFactor"><Icon Name="check" /> Verify &amp; enable</button>
+                                <button class="btn btn-ghost btn-sm" @onclick="CancelTwoFactorSetup"><Icon Name="x" /> Cancel</button>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <SettingsRow Title="Authenticator app" Sub="Not configured. Add an extra layer of protection to your account.">
+                            <button class="btn btn-pri btn-sm" @onclick="BeginTwoFactorSetup"><Icon Name="shield" /> Enable 2FA</button>
+                        </SettingsRow>
+                    }
+                </SettingsPanel>
+            }
+            else if (_panel == "access")
+            {
+                <SettingsPanel IconName="shield" Title="Login Security">
+                    <div style="font-weight:600;font-size:0.92rem;margin-bottom:4px;">Login attempts</div>
+                    <p class="sub" style="margin-bottom:14px;">Recent sign-in attempts across all IP addresses.</p>
+                    @if (_attempts.Count == 0)
+                    {
+                        <div class="empty-state"><Icon Name="clock" /><p>No login attempts recorded.</p></div>
+                    }
+                    else
+                    {
+                        <div class="card" style="overflow:hidden;">
+                            <div style="overflow-x:auto;">
+                                <table class="tbl">
+                                    <thead>
+                                        <tr>
+                                            <th style="padding-top:16px;">Time</th><th style="padding-top:16px;">User</th>
+                                            <th style="padding-top:16px;">IP</th><th style="padding-top:16px;">Result</th>
+                                            <th style="padding-top:16px;">Reason</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var a in _attempts)
+                                        {
+                                            <tr>
+                                                <td style="white-space:nowrap;">@a.CreatedAt.ToString("MMM d, yyyy HH:mm")</td>
+                                                <td>@a.Username</td>
+                                                <td class="num">@a.IpAddress</td>
+                                                <td>
+                                                    @if (a.Success)
+                                                    {
+                                                        <span class="chip up"><Icon Name="check" Width="12" Height="12" /> success</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="chip down"><Icon Name="x" Width="12" Height="12" /> failed</span>
+                                                    }
+                                                </td>
+                                                <td class="sub">@a.Reason</td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        @if (_attemptsTotalPages > 1)
+                        {
+                            <div class="flex gap-2" style="justify-content:center;align-items:center;margin-top:18px;flex-wrap:wrap;">
+                                <button class="btn btn-ghost btn-sm" disabled="@(_attemptsPage <= 1)" @onclick="() => GoToAttempts(_attemptsPage - 1)">Prev</button>
+
+                                @if (AttemptsWindow().First() > 1)
+                                {
+                                    <button class="btn btn-ghost btn-sm" style="min-width:34px;" @onclick="() => GoToAttempts(1)">1</button>
+                                    @if (AttemptsWindow().First() > 2)
+                                    {
+                                        <span class="sub" style="padding:0 2px;">…</span>
+                                    }
+                                }
+
+                                @foreach (var p in AttemptsWindow())
+                                {
+                                    var current = p;
+                                    <button class="btn btn-sm @(current == _attemptsPage ? "btn-pri" : "btn-ghost")" style="min-width:34px;" @onclick="() => GoToAttempts(current)">@current</button>
+                                }
+
+                                @if (AttemptsWindow().Last() < _attemptsTotalPages)
+                                {
+                                    @if (AttemptsWindow().Last() < _attemptsTotalPages - 1)
+                                    {
+                                        <span class="sub" style="padding:0 2px;">…</span>
+                                    }
+                                    <button class="btn btn-ghost btn-sm" style="min-width:34px;" @onclick="() => GoToAttempts(_attemptsTotalPages)">@_attemptsTotalPages</button>
+                                }
+
+                                <button class="btn btn-ghost btn-sm" disabled="@(_attemptsPage >= _attemptsTotalPages)" @onclick="() => GoToAttempts(_attemptsPage + 1)">Next</button>
+                            </div>
+                        }
+                    }
+
+                    <div style="height:1px;background:var(--border);margin:24px 0;"></div>
+
+                    <div style="font-weight:600;font-size:0.92rem;margin-bottom:4px;">IP blacklist</div>
+                    <p class="sub" style="margin-bottom:14px;line-height:1.6;">Blocked IPs cannot sign in. IPs are auto-blocked for 15 minutes after 3 failed attempts.</p>
+
+                    <div class="flex gap-2" style="align-items:flex-end;flex-wrap:wrap;margin-bottom:16px;">
+                        <div class="field" style="margin-bottom:0;"><label>IP address</label><input class="input btn-sm" style="width:180px;" @bind="_newIp" placeholder="203.0.113.7" /></div>
+                        <div class="field" style="margin-bottom:0;flex:1;min-width:160px;"><label>Reason (optional)</label><input class="input btn-sm" @bind="_newIpReason" placeholder="Manual block" /></div>
+                        <button class="btn btn-pri btn-sm" @onclick="AddBlacklist"><Icon Name="plus" /> Add IP to blacklist</button>
+                    </div>
+
+                    @if (_blacklist.Count == 0)
+                    {
+                        <div class="empty-state"><Icon Name="shield" /><p>No blacklisted IPs.</p></div>
+                    }
+                    else
+                    {
+                        <div class="card" style="overflow:hidden;">
+                            <div style="overflow-x:auto;">
+                                <table class="tbl">
+                                    <thead>
+                                        <tr>
+                                            <th style="padding-top:16px;">IP</th><th style="padding-top:16px;">User</th>
+                                            <th style="padding-top:16px;">Reason</th><th style="padding-top:16px;">Expires</th><th style="width:40px;"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var b in _blacklist)
+                                        {
+                                            <tr>
+                                                <td class="num">@b.IpAddress</td>
+                                                <td>@(string.IsNullOrEmpty(b.Username) ? "—" : b.Username)</td>
+                                                <td class="sub">@b.Reason</td>
+                                                <td style="white-space:nowrap;">@(b.ExpiresAt is null ? "permanent" : b.ExpiresAt.Value.ToString("MMM d, yyyy HH:mm"))</td>
+                                                <td>
+                                                    <button class="btn-icon btn-sm" style="width:32px;height:32px;color:var(--down);" title="Remove" @onclick="() => RemoveBlacklist(b.Id)"><Icon Name="trash" Width="15" Height="15" /></button>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    }
                 </SettingsPanel>
             }
             else if (_panel == "about")
@@ -281,6 +453,7 @@
         ("currencies", "Currency Rates", "swap"), ("database", "Database", "database"),
         ("providers", "Market Data", "trend"),
         ("appearance", "Appearance", "palette"), ("security", "Security", "lock"),
+        ("access", "Login Security", "shield"),
         ("about", "About", "info"), ("danger", "Danger Zone", "skull")
     ];
 
@@ -313,11 +486,36 @@
     private IBrowserFile? _backupFile;
     private bool _importBusy;
 
+    // ---- Two-factor auth ----
+    private bool _twoFactorEnabled;
+    private TwoFactorSetupDto? _setup;
+    private string _setupCode = "";
+    private string? _setupMsg;
+
+    // ---- Login security (access panel) ----
+    private List<LoginAttemptDto> _attempts = [];
+    private int _attemptsPage = 1;
+    private int _attemptsTotal;
+    private const int AttemptsPageSize = 25;
+    private List<BlacklistedIpDto> _blacklist = [];
+    private string _newIp = "", _newIpReason = "";
+
+    private int _attemptsTotalPages => Math.Max(1, (int)Math.Ceiling(_attemptsTotal / (double)AttemptsPageSize));
+
+    private IEnumerable<int> AttemptsWindow()
+    {
+        const int span = 2;
+        var start = Math.Max(1, _attemptsPage - span);
+        var end = Math.Min(_attemptsTotalPages, _attemptsPage + span);
+        for (var p = start; p <= end; p++) yield return p;
+    }
+
     protected override async Task OnInitializedAsync()
     {
         TopBar.Set("Settings");
         var session = await Api.GetAsync<SessionDto>("/api/auth/session");
         _base = session?.BaseCurrency ?? "EUR";
+        _twoFactorEnabled = session?.TwoFactorEnabled ?? false;
         var about = await Api.GetAsync<AboutDto>("/api/settings/about");
         _version = about?.Version ?? "1.0.0";
         var db = await Api.GetAsync<DatabaseInfoDto>("/api/settings/database");
@@ -329,6 +527,7 @@
         }
         _providers = await Api.GetAsync<List<MarketDataProviderDto>>("/api/settings/providers") ?? [];
         await LoadAll();
+        await LoadAccess();
     }
 
     private async Task LoadAll()
@@ -473,7 +672,7 @@
         _base = cur;
         await Api.PutAsync<object>("/api/auth/currency", new { base_currency = cur });
         if (Session.Value.User is { } user)
-            Dispatcher.Dispatch(new SetUserAction(new SessionDto { Username = user.Username, BaseCurrency = cur }));
+            Dispatcher.Dispatch(new SetUserAction(new SessionDto { Username = user.Username, BaseCurrency = cur, TwoFactorEnabled = user.TwoFactorEnabled }));
         Toast.Show("Main currency updated", "success");
         await LoadAll();
     }
@@ -489,6 +688,106 @@
             new { currentPassword = _curPw, newPassword = _newPw }, ApiClient.RawJson);
         if (ok) { _pwOk = true; _pwMsg = "Password updated"; _curPw = _newPw = _confirmPw = ""; }
         else { _pwOk = false; _pwMsg = json.TryGetProperty("error", out var er) ? er.GetString() : "Failed to update"; }
+    }
+
+    // ---- Two-factor auth ----
+    private async Task BeginTwoFactorSetup()
+    {
+        _setupMsg = null;
+        _setupCode = "";
+        _setup = await Api.PostAsync<TwoFactorSetupDto>("/api/auth/2fa/setup", new { });
+        if (_setup is null) Toast.Show("Could not start 2FA setup", "error");
+    }
+
+    private void CancelTwoFactorSetup()
+    {
+        _setup = null;
+        _setupCode = "";
+        _setupMsg = null;
+    }
+
+    private async Task ConfirmTwoFactor()
+    {
+        _setupMsg = null;
+        var (ok, json) = await Api.PostWithStatusAsync<JsonElement>("/api/auth/2fa/confirm", new { code = _setupCode });
+        if (ok)
+        {
+            _twoFactorEnabled = true;
+            _setup = null;
+            _setupCode = "";
+            Toast.Show("Two-factor enabled", "success");
+        }
+        else
+        {
+            _setupMsg = json.ValueKind == JsonValueKind.Object && json.TryGetProperty("error", out var er) ? er.GetString() : "Invalid code";
+        }
+    }
+
+    private async Task DisableTwoFactor()
+    {
+        if (!await Confirm.AskAsync("Disable two-factor authentication", "Your account will no longer require a one-time code at sign-in. Enter your password to confirm.", "Disable 2FA", danger: true)) return;
+        var pw = await JS.InvokeAsync<string?>("prompt", "Enter your account password to disable 2FA");
+        if (string.IsNullOrEmpty(pw)) return;
+        var (ok, json) = await Api.PostWithStatusAsync<JsonElement>("/api/auth/2fa/disable", new { password = pw });
+        if (ok)
+        {
+            _twoFactorEnabled = false;
+            Toast.Show("Two-factor disabled", "success");
+        }
+        else
+        {
+            var err = json.ValueKind == JsonValueKind.Object && json.TryGetProperty("error", out var er) ? er.GetString() : "Could not disable 2FA";
+            Toast.Show(err ?? "Could not disable 2FA", "error");
+        }
+    }
+
+    // ---- Login security (access panel) ----
+    private async Task LoadAccess()
+    {
+        var (attempts, total) = await Api.GetWithCountAsync<List<LoginAttemptDto>>($"/api/security/login-attempts?page={_attemptsPage}&page_size={AttemptsPageSize}");
+        _attempts = attempts ?? [];
+        _attemptsTotal = total;
+        _blacklist = await Api.GetAsync<List<BlacklistedIpDto>>("/api/security/blacklist") ?? [];
+        StateHasChanged();
+    }
+
+    private async Task GoToAttempts(int page)
+    {
+        var target = Math.Clamp(page, 1, _attemptsTotalPages);
+        if (target == _attemptsPage) return;
+        _attemptsPage = target;
+        var (attempts, total) = await Api.GetWithCountAsync<List<LoginAttemptDto>>($"/api/security/login-attempts?page={_attemptsPage}&page_size={AttemptsPageSize}");
+        _attempts = attempts ?? [];
+        _attemptsTotal = total;
+    }
+
+    private async Task AddBlacklist()
+    {
+        if (string.IsNullOrWhiteSpace(_newIp)) { Toast.Show("IP address required", "error"); return; }
+        var (ok, _, json) = await Api.PostWithFullStatusAsync<JsonElement>(
+            "/api/security/blacklist", new { ip_address = _newIp.Trim(), reason = _newIpReason });
+        if (ok)
+        {
+            _newIp = "";
+            _newIpReason = "";
+            Toast.Show("IP blacklisted", "success");
+            _blacklist = await Api.GetAsync<List<BlacklistedIpDto>>("/api/security/blacklist") ?? [];
+        }
+        else
+        {
+            var msg = json.ValueKind == JsonValueKind.Object
+                      && json.TryGetProperty("error", out var e) && e.ValueKind == JsonValueKind.String
+                ? e.GetString()! : "Could not add IP";
+            Toast.Show(msg, "error");
+        }
+    }
+
+    private async Task RemoveBlacklist(int id)
+    {
+        if (!await Confirm.AskAsync("Remove from blacklist", "This IP will be allowed to sign in again.", "Remove", danger: true)) return;
+        await Api.DeleteAsync<object>($"/api/security/blacklist/{id}");
+        Toast.Show("IP removed from blacklist", "success");
+        _blacklist = await Api.GetAsync<List<BlacklistedIpDto>>("/api/security/blacklist") ?? [];
     }
 
     // ---- Database ----

--- a/src/server/Server.Api/Controllers/AuthController.cs
+++ b/src/server/Server.Api/Controllers/AuthController.cs
@@ -10,15 +10,26 @@ namespace Server.Api.Controllers;
 [Route("api/auth")]
 public sealed class AuthController(IMediator mediator) : ControllerBase
 {
+    /// <summary>Step 1 of login: username + password. Returns a session, or signals that a 2FA code is required.</summary>
     [HttpPost("login")]
     public async Task<IActionResult> Login([FromBody] LoginCommand command)
     {
-        var session = await mediator.Send(command);
-        var identity = new ClaimsIdentity(
-            [new Claim(ClaimTypes.Name, session.Username)],
-            CookieAuthenticationDefaults.AuthenticationScheme);
-        await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
-        return Ok(session);
+        // The IP + user agent are taken from the request (via ForwardedHeaders), never from the body,
+        // so a client cannot spoof them to dodge the IP blacklist.
+        var result = await mediator.Send(command with { IpAddress = ClientIp(), UserAgent = UserAgentOrNull() });
+        if (!result.TwoFactorRequired && result.Session is not null)
+            await SignInAsync(result.Session);
+        return Ok(result);
+    }
+
+    /// <summary>Step 2 of login for 2FA-protected accounts: username + password + TOTP code.</summary>
+    [HttpPost("login/2fa")]
+    public async Task<IActionResult> LoginTwoFactor([FromBody] VerifyTwoFactorLoginCommand command)
+    {
+        var result = await mediator.Send(command with { IpAddress = ClientIp(), UserAgent = UserAgentOrNull() });
+        if (result.Session is not null)
+            await SignInAsync(result.Session);
+        return Ok(result);
     }
 
     [HttpPost("logout")]
@@ -46,4 +57,40 @@ public sealed class AuthController(IMediator mediator) : ControllerBase
         await mediator.Send(command);
         return Ok(new { message = "Base currency updated" });
     }
+
+    /// <summary>Begins 2FA setup: returns the secret, otpauth URI and a QR SVG to scan.</summary>
+    [HttpPost("2fa/setup")]
+    [Authorize]
+    public async Task<IActionResult> SetupTwoFactor() => Ok(await mediator.Send(new StartTwoFactorSetupCommand()));
+
+    /// <summary>Confirms and enables 2FA with a code from the authenticator app.</summary>
+    [HttpPost("2fa/confirm")]
+    [Authorize]
+    public async Task<IActionResult> ConfirmTwoFactor([FromBody] ConfirmTwoFactorCommand command)
+    {
+        await mediator.Send(command with { IpAddress = ClientIp(), UserAgent = UserAgentOrNull() });
+        return Ok(new { message = "Two-factor authentication enabled" });
+    }
+
+    /// <summary>Disables 2FA (requires the account password).</summary>
+    [HttpPost("2fa/disable")]
+    [Authorize]
+    public async Task<IActionResult> DisableTwoFactor([FromBody] DisableTwoFactorCommand command)
+    {
+        await mediator.Send(command with { IpAddress = ClientIp(), UserAgent = UserAgentOrNull() });
+        return Ok(new { message = "Two-factor authentication disabled" });
+    }
+
+    private async Task SignInAsync(SessionDto session)
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, session.Username)],
+            CookieAuthenticationDefaults.AuthenticationScheme);
+        await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
+    }
+
+    private string ClientIp() => HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+    private string? UserAgentOrNull() =>
+        Request.Headers.UserAgent.ToString() is { Length: > 0 } ua ? ua : null;
 }

--- a/src/server/Server.Api/Controllers/SecurityController.cs
+++ b/src/server/Server.Api/Controllers/SecurityController.cs
@@ -1,0 +1,37 @@
+using Server.Application.Security.Commands;
+using Server.Application.Security.Queries;
+
+namespace Server.Api.Controllers;
+
+/// <summary>Login-security management: the sign-in audit log and the IP blacklist.</summary>
+[ApiController]
+[Authorize]
+[Route("api/security")]
+public sealed class SecurityController(IMediator mediator) : ControllerBase
+{
+    /// <summary>A most-recent-first page of login attempts; the total is returned via X-Total-Count.</summary>
+    [HttpGet("login-attempts")]
+    public async Task<IActionResult> LoginAttempts([FromQuery] int? page, [FromQuery(Name = "page_size")] int? pageSize)
+    {
+        var total = await mediator.Send(new GetLoginAttemptsCountQuery());
+        Response.Headers.Append("X-Total-Count", total.ToString());
+        return Ok(await mediator.Send(new GetLoginAttemptsQuery(page, pageSize)));
+    }
+
+    /// <summary>The active (non-expired) IP blacklist entries.</summary>
+    [HttpGet("blacklist")]
+    public async Task<IActionResult> Blacklist() => Ok(await mediator.Send(new GetBlacklistQuery()));
+
+    /// <summary>Manually blocks an IP (permanent until removed).</summary>
+    [HttpPost("blacklist")]
+    public async Task<IActionResult> AddBlacklist([FromBody] AddBlacklistCommand command) =>
+        StatusCode(StatusCodes.Status201Created, await mediator.Send(command));
+
+    /// <summary>Removes a blacklist entry (unblocking the IP).</summary>
+    [HttpDelete("blacklist/{id:int}")]
+    public async Task<IActionResult> RemoveBlacklist(int id)
+    {
+        await mediator.Send(new RemoveBlacklistCommand(id));
+        return Ok(new { message = "Blacklist entry removed" });
+    }
+}

--- a/src/server/Server.Api/GlobalUsings.cs
+++ b/src/server/Server.Api/GlobalUsings.cs
@@ -9,3 +9,4 @@ global using Server.Application.Currencies;
 global using Server.Application.Auth;
 global using Server.Application.Prices;
 global using Server.Application.Settings;
+global using Server.Application.Security;

--- a/src/server/Server.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/server/Server.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -16,6 +16,7 @@ public sealed class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<Ex
         catch (NotFoundException ex) { await Write(context, StatusCodes.Status404NotFound, ex.Message); }
         catch (ConflictException ex) { await Write(context, StatusCodes.Status409Conflict, ex.Message); }
         catch (UnauthorizedException ex) { await Write(context, StatusCodes.Status401Unauthorized, ex.Message); }
+        catch (TooManyRequestsException ex) { await Write(context, StatusCodes.Status429TooManyRequests, ex.Message); }
         catch (DomainException ex) { await Write(context, StatusCodes.Status400BadRequest, ex.Message); }
         catch (Exception ex)
         {

--- a/src/server/Server.Api/Program.cs
+++ b/src/server/Server.Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
@@ -5,6 +6,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.OpenApi.Models;
 using Server.Api.Auth;
 using Server.Api.Middleware;
+using Server.Api.Services;
 using Server.Application;
 using Server.Application.Common.Interfaces;
 using Server.Infrastructure;
@@ -58,12 +60,26 @@ var dataDir = Path.GetDirectoryName(dbPath);
 builder.Services.AddDataProtection()
     .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(dataDir ?? ".", "dp-keys")));
 
-// Behind nginx — honour X-Forwarded-* headers.
+// Prune old sign-in audit rows on a schedule so the attempts table can't grow unbounded.
+builder.Services.AddHostedService<LoginAttemptRetentionService>();
+
+// Behind nginx — honour X-Forwarded-* headers, but ONLY when the immediate peer is a private-network
+// proxy. Trusting every proxy (KnownIPNetworks.Clear()) would let anyone who could reach the API port
+// directly forge X-Forwarded-For to spoof the client IP the blacklist/rate-limiter keys on. Restricting
+// trust to the private ranges (where the nginx sidecar lives) keeps the real client IP correct behind
+// the proxy while ignoring a forged header from any public direct connection.
 builder.Services.Configure<ForwardedHeadersOptions>(o =>
 {
     o.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
+    o.ForwardLimit = null; // walk the whole chain, popping trusted (private) hops until the real client IP
     o.KnownIPNetworks.Clear();
     o.KnownProxies.Clear();
+    o.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+    o.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("172.16.0.0"), 12));
+    o.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("192.168.0.0"), 16));
+    o.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("127.0.0.0"), 8));
+    o.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.IPv6Loopback, 128));
+    o.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("fc00::"), 7)); // IPv6 unique-local
 });
 
 // Optional CORS for separate-origin dev.

--- a/src/server/Server.Api/Services/LoginAttemptRetentionService.cs
+++ b/src/server/Server.Api/Services/LoginAttemptRetentionService.cs
@@ -1,0 +1,39 @@
+using Server.Application.Common.Interfaces;
+
+namespace Server.Api.Services;
+
+/// <summary>
+/// Periodically prunes old sign-in audit rows so the <c>LoginAttempts</c> table can't grow without
+/// bound (a distributed, IP-rotating attacker would otherwise fill the disk). Runs once at startup
+/// and then on a fixed interval, deleting anything past the retention horizon.
+/// </summary>
+public sealed class LoginAttemptRetentionService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<LoginAttemptRetentionService> logger) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(12);
+    private static readonly TimeSpan Retention = TimeSpan.FromDays(90);
+
+    /// <summary>Sweeps expired attempts every <see cref="Interval"/> until the app shuts down.</summary>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var attempts = scope.ServiceProvider.GetRequiredService<ILoginAttemptRepository>();
+                var removed = await attempts.DeleteOlderThanAsync(DateTime.UtcNow - Retention, stoppingToken);
+                if (removed > 0)
+                    logger.LogInformation("Pruned {Count} login attempts older than {Days} days", removed, (int)Retention.TotalDays);
+            }
+            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+            {
+                logger.LogError(ex, "Login-attempt retention sweep failed");
+            }
+
+            try { await Task.Delay(Interval, stoppingToken); }
+            catch (TaskCanceledException) { break; }
+        }
+    }
+}

--- a/src/server/Server.Application/Auth/Commands/ConfirmTwoFactorCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/ConfirmTwoFactorCommand.cs
@@ -1,0 +1,46 @@
+using Server.Application.Common.Exceptions;
+
+namespace Server.Application.Auth.Commands;
+
+/// <summary>Confirms and activates 2FA by validating a code against the pending secret.</summary>
+/// <param name="Code">The 6-digit code from the authenticator app.</param>
+/// <param name="IpAddress">The client IP, populated by the controller (never trusted from the body).</param>
+/// <param name="UserAgent">The client user agent, populated by the controller.</param>
+public record ConfirmTwoFactorCommand(string? Code, string? IpAddress, string? UserAgent) : IRequest;
+
+/// <summary>Handles <see cref="ConfirmTwoFactorCommand"/>.</summary>
+public sealed class ConfirmTwoFactorHandler(
+    ICurrentUser currentUser,
+    IUserRepository users,
+    ITotpService totp,
+    ILoginSecurityService security,
+    IUnitOfWork uow,
+    ILogger<ConfirmTwoFactorHandler> logger)
+    : IRequestHandler<ConfirmTwoFactorCommand>
+{
+    /// <summary>Verifies the code against the pending secret and activates 2FA (rate-limited by the IP block).</summary>
+    public async Task Handle(ConfirmTwoFactorCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(ConfirmTwoFactorCommand));
+
+        if (!currentUser.IsAuthenticated)
+            throw new UnauthorizedException("Not authenticated");
+        var user = await users.GetByUsernameAsync(currentUser.Username!, cancellationToken)
+                   ?? throw new UnauthorizedException("Not authenticated");
+
+        // Throttle code-guessing: a blocked IP is refused, and each wrong code counts toward the block.
+        var ip = request.IpAddress ?? "unknown";
+        if (await security.IsIpBlockedAsync(ip, cancellationToken))
+            throw new TooManyRequestsException("Too many failed attempts. Try again in a few minutes.");
+
+        // VerifyCode returns false when no setup secret exists, so this also guards "setup not started".
+        if (!totp.VerifyCode(user.TwoFactorSecret, request.Code))
+        {
+            await security.RecordAttemptAsync(user.Username, ip, false, "invalid_2fa_confirm", request.UserAgent, cancellationToken);
+            throw new UnauthorizedException("Invalid authentication code");
+        }
+
+        user.ConfirmTwoFactor();
+        await uow.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Auth/Commands/DisableTwoFactorCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/DisableTwoFactorCommand.cs
@@ -1,0 +1,46 @@
+using Server.Application.Common.Exceptions;
+
+namespace Server.Application.Auth.Commands;
+
+/// <summary>Disables 2FA after re-verifying the account password.</summary>
+/// <param name="Password">The account password, required to turn 2FA off.</param>
+/// <param name="IpAddress">The client IP, populated by the controller (never trusted from the body).</param>
+/// <param name="UserAgent">The client user agent, populated by the controller.</param>
+public record DisableTwoFactorCommand(string? Password, string? IpAddress, string? UserAgent) : IRequest;
+
+/// <summary>Handles <see cref="DisableTwoFactorCommand"/>.</summary>
+public sealed class DisableTwoFactorHandler(
+    ICurrentUser currentUser,
+    IUserRepository users,
+    IPasswordHasher hasher,
+    ILoginSecurityService security,
+    IUnitOfWork uow,
+    ILogger<DisableTwoFactorHandler> logger)
+    : IRequestHandler<DisableTwoFactorCommand>
+{
+    /// <summary>Verifies the password (rate-limited by the IP block), then turns 2FA off and discards the secret.</summary>
+    public async Task Handle(DisableTwoFactorCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(DisableTwoFactorCommand));
+
+        if (!currentUser.IsAuthenticated)
+            throw new UnauthorizedException("Not authenticated");
+        var user = await users.GetByUsernameAsync(currentUser.Username!, cancellationToken)
+                   ?? throw new UnauthorizedException("Not authenticated");
+
+        // A stolen session cookie must not allow unlimited password guesses to strip 2FA off: a
+        // blocked IP is refused, and each wrong password counts toward the block.
+        var ip = request.IpAddress ?? "unknown";
+        if (await security.IsIpBlockedAsync(ip, cancellationToken))
+            throw new TooManyRequestsException("Too many failed attempts. Try again in a few minutes.");
+
+        if (!hasher.Verify(request.Password ?? "", user.PasswordHash))
+        {
+            await security.RecordAttemptAsync(user.Username, ip, false, "invalid_password_disable", request.UserAgent, cancellationToken);
+            throw new UnauthorizedException("Password is incorrect");
+        }
+
+        user.DisableTwoFactor();
+        await uow.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Auth/Commands/LoginCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/LoginCommand.cs
@@ -2,27 +2,49 @@ using Server.Application.Common.Exceptions;
 
 namespace Server.Application.Auth.Commands;
 
-/// <summary>Authenticates a user with a username and password.</summary>
+/// <summary>Authenticates a user with a username and password (the first login step).</summary>
 /// <param name="Username">The username.</param>
 /// <param name="Password">The plaintext password.</param>
-public record LoginCommand(string? Username, string? Password) : IRequest<SessionDto>;
+/// <param name="IpAddress">The client IP, populated by the controller from the request.</param>
+/// <param name="UserAgent">The client user agent, populated by the controller.</param>
+public record LoginCommand(string? Username, string? Password, string? IpAddress, string? UserAgent)
+    : IRequest<LoginResultDto>;
 
 /// <summary>Handles <see cref="LoginCommand"/>.</summary>
 public sealed class LoginHandler(
     IUserRepository users,
     IPasswordHasher hasher,
+    ILoginSecurityService security,
     ILogger<LoginHandler> logger)
-    : IRequestHandler<LoginCommand, SessionDto>
+    : IRequestHandler<LoginCommand, LoginResultDto>
 {
-    /// <summary>Verifies the credentials and returns the resulting session.</summary>
-    public async Task<SessionDto> Handle(LoginCommand request, CancellationToken cancellationToken)
+    /// <summary>Rejects blocked IPs, verifies the password, and either signs in or requests the second factor.</summary>
+    public async Task<LoginResultDto> Handle(LoginCommand request, CancellationToken cancellationToken)
     {
         logger.LogInformation("Handling {Request}", nameof(LoginCommand));
+        var ip = request.IpAddress ?? "unknown";
+
+        // Blocked IPs are rejected before any credential check — no information leak, no timing oracle.
+        // We do NOT record blocked hits: the block is already audited, and skipping them bounds how
+        // much a hammering attacker can grow the attempts table while blocked.
+        if (await security.IsIpBlockedAsync(ip, cancellationToken))
+            throw new TooManyRequestsException("Too many failed attempts. This IP is temporarily blocked — try again in a few minutes.");
 
         var user = await users.GetByUsernameAsync(request.Username ?? "", cancellationToken);
-        if (user is null || !hasher.Verify(request.Password ?? "", user.PasswordHash))
+        // Always run the hash verification (against a dummy hash when the user is unknown) so the
+        // response time doesn't reveal whether the username exists.
+        var passwordOk = hasher.Verify(request.Password ?? "", user?.PasswordHash ?? hasher.DummyHash);
+        if (user is null || !passwordOk)
+        {
+            await security.RecordAttemptAsync(request.Username, ip, false, "invalid_password", request.UserAgent, cancellationToken);
             throw new UnauthorizedException("Invalid credentials");
+        }
 
-        return new SessionDto(user.Username, user.BaseCurrency.Value);
+        // Password correct — if 2FA is on, do NOT sign in yet; the controller must not set the cookie.
+        if (user.TwoFactorEnabled)
+            return LoginResultDto.Requires2Fa();
+
+        await security.RecordAttemptAsync(user.Username, ip, true, "success", request.UserAgent, cancellationToken);
+        return LoginResultDto.SignedIn(new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled));
     }
 }

--- a/src/server/Server.Application/Auth/Commands/StartTwoFactorSetupCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/StartTwoFactorSetupCommand.cs
@@ -1,0 +1,43 @@
+using Server.Application.Common.Exceptions;
+
+namespace Server.Application.Auth.Commands;
+
+/// <summary>Begins 2FA setup for the current user: generates a secret and returns it plus a QR to scan.</summary>
+public record StartTwoFactorSetupCommand : IRequest<TwoFactorSetupDto>;
+
+/// <summary>Handles <see cref="StartTwoFactorSetupCommand"/>.</summary>
+public sealed class StartTwoFactorSetupHandler(
+    ICurrentUser currentUser,
+    IUserRepository users,
+    ITotpService totp,
+    IUnitOfWork uow,
+    ILogger<StartTwoFactorSetupHandler> logger)
+    : IRequestHandler<StartTwoFactorSetupCommand, TwoFactorSetupDto>
+{
+    private const string Issuer = "Capitrack";
+
+    /// <summary>Generates and stores a pending TOTP secret (2FA stays disabled until confirmed) and returns the setup payload.</summary>
+    public async Task<TwoFactorSetupDto> Handle(StartTwoFactorSetupCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(StartTwoFactorSetupCommand));
+
+        if (!currentUser.IsAuthenticated)
+            throw new UnauthorizedException("Not authenticated");
+        var user = await users.GetByUsernameAsync(currentUser.Username!, cancellationToken)
+                   ?? throw new UnauthorizedException("Not authenticated");
+
+        // Reuse an existing secret rather than minting a fresh one on every call: this makes setup
+        // idempotent, so a repeated request can't invalidate a QR the user has already scanned, and
+        // it never silently disables an already-active 2FA.
+        var secret = string.IsNullOrWhiteSpace(user.TwoFactorSecret) ? totp.GenerateSecret() : user.TwoFactorSecret!;
+        if (!user.TwoFactorEnabled)
+        {
+            user.BeginTwoFactorSetup(secret);
+            await uow.SaveChangesAsync(cancellationToken);
+        }
+
+        var uri = totp.BuildOtpAuthUri(secret, user.Username, Issuer);
+        var svg = totp.GenerateQrSvg(uri);
+        return new TwoFactorSetupDto(secret, uri, svg);
+    }
+}

--- a/src/server/Server.Application/Auth/Commands/VerifyTwoFactorLoginCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/VerifyTwoFactorLoginCommand.cs
@@ -1,0 +1,57 @@
+using Server.Application.Common.Exceptions;
+
+namespace Server.Application.Auth.Commands;
+
+/// <summary>Completes a 2FA-protected login: re-checks the password and validates the TOTP code (the second step).</summary>
+/// <param name="Username">The username.</param>
+/// <param name="Password">The plaintext password (re-sent so the step is stateless).</param>
+/// <param name="Code">The 6-digit TOTP code from the authenticator app.</param>
+/// <param name="IpAddress">The client IP, populated by the controller.</param>
+/// <param name="UserAgent">The client user agent, populated by the controller.</param>
+public record VerifyTwoFactorLoginCommand(string? Username, string? Password, string? Code, string? IpAddress, string? UserAgent)
+    : IRequest<LoginResultDto>;
+
+/// <summary>Handles <see cref="VerifyTwoFactorLoginCommand"/>.</summary>
+public sealed class VerifyTwoFactorLoginHandler(
+    IUserRepository users,
+    IPasswordHasher hasher,
+    ITotpService totp,
+    ILoginSecurityService security,
+    ILogger<VerifyTwoFactorLoginHandler> logger)
+    : IRequestHandler<VerifyTwoFactorLoginCommand, LoginResultDto>
+{
+    /// <summary>Re-verifies the password and TOTP code (a bad code counts toward the auto-block), then returns the session.</summary>
+    public async Task<LoginResultDto> Handle(VerifyTwoFactorLoginCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(VerifyTwoFactorLoginCommand));
+        var ip = request.IpAddress ?? "unknown";
+
+        if (await security.IsIpBlockedAsync(ip, cancellationToken))
+            throw new TooManyRequestsException("Too many failed attempts. This IP is temporarily blocked — try again in a few minutes.");
+
+        var user = await users.GetByUsernameAsync(request.Username ?? "", cancellationToken);
+        // Constant-time password check (dummy hash when unknown) to avoid a user-enumeration timing oracle.
+        var passwordOk = hasher.Verify(request.Password ?? "", user?.PasswordHash ?? hasher.DummyHash);
+        if (user is null || !passwordOk)
+        {
+            await security.RecordAttemptAsync(request.Username, ip, false, "invalid_password", request.UserAgent, cancellationToken);
+            throw new UnauthorizedException("Invalid credentials");
+        }
+
+        // This endpoint is only for 2FA-protected accounts. If 2FA isn't enabled, reject rather than
+        // signing in on the password alone (the normal /login path handles non-2FA accounts).
+        if (!user.TwoFactorEnabled)
+            throw new UnauthorizedException("Invalid credentials");
+
+        // The TOTP code is verified unconditionally — a wrong code is a genuine failed attempt, so
+        // brute-forcing the code triggers the IP block too.
+        if (!totp.VerifyCode(user.TwoFactorSecret, request.Code))
+        {
+            await security.RecordAttemptAsync(user.Username, ip, false, "invalid_2fa", request.UserAgent, cancellationToken);
+            throw new UnauthorizedException("Invalid authentication code");
+        }
+
+        await security.RecordAttemptAsync(user.Username, ip, true, "success", request.UserAgent, cancellationToken);
+        return LoginResultDto.SignedIn(new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled));
+    }
+}

--- a/src/server/Server.Application/Auth/LoginResultDto.cs
+++ b/src/server/Server.Application/Auth/LoginResultDto.cs
@@ -1,0 +1,16 @@
+namespace Server.Application.Auth;
+
+/// <summary>
+/// The outcome of a sign-in step: either the second factor is still required, or the user
+/// is fully authenticated and a <see cref="SessionDto"/> is returned.
+/// </summary>
+/// <param name="TwoFactorRequired">True when the password was correct but a TOTP code is still needed.</param>
+/// <param name="Session">The session — present only once fully signed in.</param>
+public record LoginResultDto(bool TwoFactorRequired, SessionDto? Session)
+{
+    /// <summary>Password accepted, but a TOTP code is required to complete sign-in.</summary>
+    public static LoginResultDto Requires2Fa() => new(true, null);
+
+    /// <summary>Fully signed in.</summary>
+    public static LoginResultDto SignedIn(SessionDto session) => new(false, session);
+}

--- a/src/server/Server.Application/Auth/Queries/GetSessionQuery.cs
+++ b/src/server/Server.Application/Auth/Queries/GetSessionQuery.cs
@@ -23,6 +23,6 @@ public sealed class GetSessionQueryHandler(
         var user = await users.GetByUsernameAsync(currentUser.Username!, cancellationToken)
                    ?? throw new UnauthorizedException("Not authenticated");
 
-        return new SessionDto(user.Username, user.BaseCurrency.Value);
+        return new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled);
     }
 }

--- a/src/server/Server.Application/Auth/SessionDto.cs
+++ b/src/server/Server.Application/Auth/SessionDto.cs
@@ -3,4 +3,5 @@ namespace Server.Application.Auth;
 /// <summary>The authenticated session, returned by login and session queries.</summary>
 /// <param name="Username">The signed-in user's name.</param>
 /// <param name="BaseCurrency">The user's base currency code.</param>
-public record SessionDto(string Username, string BaseCurrency);
+/// <param name="TwoFactorEnabled">Whether two-factor authentication is active for the user.</param>
+public record SessionDto(string Username, string BaseCurrency, bool TwoFactorEnabled);

--- a/src/server/Server.Application/Auth/TwoFactorSetupDto.cs
+++ b/src/server/Server.Application/Auth/TwoFactorSetupDto.cs
@@ -1,0 +1,7 @@
+namespace Server.Application.Auth;
+
+/// <summary>The data returned when starting 2FA setup, for the user to add to their authenticator app.</summary>
+/// <param name="Secret">The base32 TOTP secret (for manual entry).</param>
+/// <param name="OtpauthUri">The otpauth:// URI encoded in the QR code.</param>
+/// <param name="QrSvg">A self-contained SVG QR code the user can scan.</param>
+public record TwoFactorSetupDto(string Secret, string OtpauthUri, string QrSvg);

--- a/src/server/Server.Application/Common/Exceptions/TooManyRequestsException.cs
+++ b/src/server/Server.Application/Common/Exceptions/TooManyRequestsException.cs
@@ -1,0 +1,8 @@
+namespace Server.Application.Common.Exceptions;
+
+/// <summary>Too many attempts / the client is rate-limited or blocked. Maps to HTTP 429.</summary>
+public sealed class TooManyRequestsException : Exception
+{
+    /// <summary>Creates the exception with the given message.</summary>
+    public TooManyRequestsException(string message) : base(message) { }
+}

--- a/src/server/Server.Application/Common/Interfaces/IBlacklistRepository.cs
+++ b/src/server/Server.Application/Common/Interfaces/IBlacklistRepository.cs
@@ -1,0 +1,25 @@
+using Server.Domain.Security;
+
+namespace Server.Application.Common.Interfaces;
+
+/// <summary>Persistence for the IP blacklist (manual + automatic blocks).</summary>
+public interface IBlacklistRepository
+{
+    /// <summary>Returns the active (non-expired) block for an IP, or null.</summary>
+    Task<BlacklistedIp?> GetActiveByIpAsync(string ipAddress, DateTime now, CancellationToken ct = default);
+
+    /// <summary>Returns an existing MANUAL (never-expiring) block for an IP, or null (used to avoid duplicate manual entries).</summary>
+    Task<BlacklistedIp?> GetManualByIpAsync(string ipAddress, CancellationToken ct = default);
+
+    /// <summary>Returns all active (non-expired) blocks, newest first.</summary>
+    Task<IReadOnlyList<BlacklistedIp>> ListActiveAsync(DateTime now, CancellationToken ct = default);
+
+    /// <summary>Returns a block by id, or null.</summary>
+    Task<BlacklistedIp?> GetAsync(int id, CancellationToken ct = default);
+
+    /// <summary>Tracks a new block for insertion.</summary>
+    Task AddAsync(BlacklistedIp entry, CancellationToken ct = default);
+
+    /// <summary>Marks a block for deletion.</summary>
+    void Remove(BlacklistedIp entry);
+}

--- a/src/server/Server.Application/Common/Interfaces/ILoginAttemptRepository.cs
+++ b/src/server/Server.Application/Common/Interfaces/ILoginAttemptRepository.cs
@@ -1,0 +1,22 @@
+using Server.Domain.Security;
+
+namespace Server.Application.Common.Interfaces;
+
+/// <summary>Persistence for sign-in audit records.</summary>
+public interface ILoginAttemptRepository
+{
+    /// <summary>Records a sign-in attempt.</summary>
+    Task AddAsync(LoginAttempt attempt, CancellationToken ct = default);
+
+    /// <summary>Counts FAILED attempts from an IP since the given instant (for brute-force detection).</summary>
+    Task<int> CountRecentFailuresAsync(string ipAddress, DateTime since, CancellationToken ct = default);
+
+    /// <summary>Returns a most-recent-first page of attempts.</summary>
+    Task<IReadOnlyList<LoginAttempt>> ListAsync(int limit, int offset, CancellationToken ct = default);
+
+    /// <summary>Total number of recorded attempts.</summary>
+    Task<int> CountAsync(CancellationToken ct = default);
+
+    /// <summary>Deletes attempts older than the cutoff (retention). Returns the number removed.</summary>
+    Task<int> DeleteOlderThanAsync(DateTime cutoff, CancellationToken ct = default);
+}

--- a/src/server/Server.Application/Common/Interfaces/ILoginSecurityService.cs
+++ b/src/server/Server.Application/Common/Interfaces/ILoginSecurityService.cs
@@ -1,0 +1,18 @@
+namespace Server.Application.Common.Interfaces;
+
+/// <summary>
+/// Centralises the brute-force protection shared by the password and 2FA login steps:
+/// checking whether an IP is blocked, auditing every attempt, and auto-blocking an IP
+/// after too many failures. Keeps the two login handlers free of duplicated security logic.
+/// </summary>
+public interface ILoginSecurityService
+{
+    /// <summary>True when the IP currently has an active (non-expired) blacklist entry.</summary>
+    Task<bool> IsIpBlockedAsync(string ipAddress, CancellationToken ct = default);
+
+    /// <summary>
+    /// Records a sign-in attempt. On a genuine credential/2FA failure it evaluates the
+    /// 3-strikes-in-15-minutes rule and adds a 15-minute IP block when the threshold is hit.
+    /// </summary>
+    Task RecordAttemptAsync(string? username, string ipAddress, bool success, string reason, string? userAgent, CancellationToken ct = default);
+}

--- a/src/server/Server.Application/Common/Interfaces/IPasswordHasher.cs
+++ b/src/server/Server.Application/Common/Interfaces/IPasswordHasher.cs
@@ -8,4 +8,10 @@ public interface IPasswordHasher
 
     /// <summary>Verifies a plaintext password against a stored hash.</summary>
     bool Verify(string password, string hash);
+
+    /// <summary>
+    /// A valid, throwaway hash to verify against when the account does not exist, so an
+    /// unknown-username login costs the same time as a known one (defeats user enumeration).
+    /// </summary>
+    string DummyHash { get; }
 }

--- a/src/server/Server.Application/Common/Interfaces/ITotpService.cs
+++ b/src/server/Server.Application/Common/Interfaces/ITotpService.cs
@@ -1,0 +1,17 @@
+namespace Server.Application.Common.Interfaces;
+
+/// <summary>TOTP (RFC 6238) two-factor helpers: secret generation, the otpauth URI + QR, and code verification.</summary>
+public interface ITotpService
+{
+    /// <summary>Generates a new random base32 TOTP secret.</summary>
+    string GenerateSecret();
+
+    /// <summary>Builds the <c>otpauth://</c> URI that an authenticator app scans.</summary>
+    string BuildOtpAuthUri(string secret, string account, string issuer);
+
+    /// <summary>Renders an otpauth URI as a self-contained SVG QR code.</summary>
+    string GenerateQrSvg(string otpauthUri);
+
+    /// <summary>Verifies a 6-digit TOTP code against the secret, allowing a small clock-skew window.</summary>
+    bool VerifyCode(string? secret, string? code);
+}

--- a/src/server/Server.Application/GlobalUsings.cs
+++ b/src/server/Server.Application/GlobalUsings.cs
@@ -14,3 +14,4 @@ global using Server.Application.Currencies;
 global using Server.Application.Auth;
 global using Server.Application.Prices;
 global using Server.Application.Settings;
+global using Server.Application.Security;

--- a/src/server/Server.Application/Security/BlacklistedIpDto.cs
+++ b/src/server/Server.Application/Security/BlacklistedIpDto.cs
@@ -1,0 +1,11 @@
+namespace Server.Application.Security;
+
+/// <summary>API representation of a blacklisted IP.</summary>
+/// <param name="Id">The record identifier.</param>
+/// <param name="IpAddress">The blocked IP.</param>
+/// <param name="Username">The associated username (for automatic blocks), if any.</param>
+/// <param name="Reason">Why it was blocked.</param>
+/// <param name="CreatedAt">When the block was created (UTC).</param>
+/// <param name="ExpiresAt">When the block lifts (UTC); null means it never expires (a manual block).</param>
+public record BlacklistedIpDto(
+    int Id, string IpAddress, string? Username, string Reason, DateTime CreatedAt, DateTime? ExpiresAt);

--- a/src/server/Server.Application/Security/Commands/AddBlacklistCommand.cs
+++ b/src/server/Server.Application/Security/Commands/AddBlacklistCommand.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Sockets;
+using Server.Domain.Security;
+
+namespace Server.Application.Security.Commands;
+
+/// <summary>Manually adds a (permanent) IP block.</summary>
+/// <param name="IpAddress">The IP to block.</param>
+/// <param name="Reason">An optional reason.</param>
+public record AddBlacklistCommand(string? IpAddress, string? Reason) : IRequest<BlacklistedIpDto>;
+
+/// <summary>Validates <see cref="AddBlacklistCommand"/>.</summary>
+public sealed class AddBlacklistValidator : AbstractValidator<AddBlacklistCommand>
+{
+    /// <summary>Requires a syntactically valid, publicly-routable IP address.</summary>
+    public AddBlacklistValidator()
+    {
+        RuleFor(x => x.IpAddress)
+            .NotEmpty().WithMessage("An IP address is required.")
+            .Must(ip => IPAddress.TryParse((ip ?? "").Trim(), out _)).WithMessage("Enter a valid IP address.")
+            .Must(IsPubliclyRoutable)
+                .WithMessage("Only public IP addresses can be blocked — private, loopback and link-local ranges are rejected (blocking them could lock you or the proxy out).");
+    }
+
+    /// <summary>
+    /// Rejects addresses that must never be blacklisted: loopback, private (RFC 1918 / ULA),
+    /// link-local, multicast and unspecified. These are the reverse-proxy / admin ranges, so
+    /// blocking them would deny service to every user (or to the operator).
+    /// </summary>
+    private static bool IsPubliclyRoutable(string? value)
+    {
+        if (!IPAddress.TryParse((value ?? "").Trim(), out var ip)) return false;   // handled by the parse rule above
+        if (IPAddress.IsLoopback(ip)) return false;
+
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = ip.GetAddressBytes();
+            if (b[0] == 0) return false;                              // 0.0.0.0/8 unspecified
+            if (b[0] == 10) return false;                             // 10.0.0.0/8
+            if (b[0] == 127) return false;                           // loopback
+            if (b[0] == 169 && b[1] == 254) return false;            // 169.254.0.0/16 link-local
+            if (b[0] == 172 && b[1] >= 16 && b[1] <= 31) return false; // 172.16.0.0/12
+            if (b[0] == 192 && b[1] == 168) return false;            // 192.168.0.0/16
+            if (b[0] >= 224) return false;                           // 224+ multicast / reserved
+            return true;
+        }
+
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (ip.IsIPv6LinkLocal || ip.IsIPv6SiteLocal || ip.IsIPv6Multicast) return false;
+            if (ip.Equals(IPAddress.IPv6Loopback) || ip.Equals(IPAddress.IPv6Any)) return false;
+            var b = ip.GetAddressBytes();
+            if ((b[0] & 0xFE) == 0xFC) return false;                 // fc00::/7 unique-local
+            return true;
+        }
+
+        return false;
+    }
+}
+
+/// <summary>Handles <see cref="AddBlacklistCommand"/>.</summary>
+public sealed class AddBlacklistHandler(
+    IBlacklistRepository blacklist,
+    IUnitOfWork uow,
+    IMapper mapper,
+    ILogger<AddBlacklistHandler> logger)
+    : IRequestHandler<AddBlacklistCommand, BlacklistedIpDto>
+{
+    /// <summary>Adds a permanent manual block (idempotent per IP) and returns the resulting DTO.</summary>
+    public async Task<BlacklistedIpDto> Handle(AddBlacklistCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(AddBlacklistCommand));
+
+        var ip = request.IpAddress!.Trim();
+        var existing = await blacklist.GetManualByIpAsync(ip, cancellationToken);
+        if (existing is not null)
+            return mapper.Map<BlacklistedIpDto>(existing);
+
+        var entry = BlacklistedIp.Manual(ip, request.Reason);
+        await blacklist.AddAsync(entry, cancellationToken);
+        await uow.SaveChangesAsync(cancellationToken);
+        return mapper.Map<BlacklistedIpDto>(entry);
+    }
+}

--- a/src/server/Server.Application/Security/Commands/RemoveBlacklistCommand.cs
+++ b/src/server/Server.Application/Security/Commands/RemoveBlacklistCommand.cs
@@ -1,0 +1,26 @@
+using Server.Application.Common.Exceptions;
+
+namespace Server.Application.Security.Commands;
+
+/// <summary>Removes an IP blacklist entry (manual or automatic) by id.</summary>
+/// <param name="Id">The entry identifier.</param>
+public record RemoveBlacklistCommand(int Id) : IRequest;
+
+/// <summary>Handles <see cref="RemoveBlacklistCommand"/>.</summary>
+public sealed class RemoveBlacklistHandler(
+    IBlacklistRepository blacklist,
+    IUnitOfWork uow,
+    ILogger<RemoveBlacklistHandler> logger)
+    : IRequestHandler<RemoveBlacklistCommand>
+{
+    /// <summary>Deletes the blacklist entry, unblocking the IP.</summary>
+    public async Task Handle(RemoveBlacklistCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(RemoveBlacklistCommand));
+
+        var entry = await blacklist.GetAsync(request.Id, cancellationToken)
+                    ?? throw new NotFoundException("Blacklist entry not found");
+        blacklist.Remove(entry);
+        await uow.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Security/LoginAttemptDto.cs
+++ b/src/server/Server.Application/Security/LoginAttemptDto.cs
@@ -1,0 +1,12 @@
+namespace Server.Application.Security;
+
+/// <summary>API representation of an audited sign-in attempt.</summary>
+/// <param name="Id">The record identifier.</param>
+/// <param name="Username">The username that was tried.</param>
+/// <param name="IpAddress">The client IP the attempt came from.</param>
+/// <param name="Success">Whether it succeeded.</param>
+/// <param name="Reason">A short outcome code (e.g. "success", "invalid_password", "invalid_2fa", "ip_blocked").</param>
+/// <param name="CreatedAt">When it happened (UTC).</param>
+/// <param name="UserAgent">The requesting user agent, if captured.</param>
+public record LoginAttemptDto(
+    int Id, string Username, string IpAddress, bool Success, string Reason, DateTime CreatedAt, string? UserAgent);

--- a/src/server/Server.Application/Security/Queries/GetBlacklistQuery.cs
+++ b/src/server/Server.Application/Security/Queries/GetBlacklistQuery.cs
@@ -1,0 +1,20 @@
+namespace Server.Application.Security.Queries;
+
+/// <summary>Returns all active (non-expired) IP blacklist entries, newest first.</summary>
+public record GetBlacklistQuery : IRequest<List<BlacklistedIpDto>>;
+
+/// <summary>Handles <see cref="GetBlacklistQuery"/>.</summary>
+public sealed class GetBlacklistQueryHandler(
+    IBlacklistRepository blacklist,
+    IMapper mapper,
+    ILogger<GetBlacklistQueryHandler> logger)
+    : IRequestHandler<GetBlacklistQuery, List<BlacklistedIpDto>>
+{
+    /// <summary>Loads the active blacklist and returns the resulting DTOs.</summary>
+    public async Task<List<BlacklistedIpDto>> Handle(GetBlacklistQuery request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(GetBlacklistQuery));
+        var items = await blacklist.ListActiveAsync(DateTime.UtcNow, cancellationToken);
+        return items.Select(b => mapper.Map<BlacklistedIpDto>(b)).ToList();
+    }
+}

--- a/src/server/Server.Application/Security/Queries/GetLoginAttemptsQuery.cs
+++ b/src/server/Server.Application/Security/Queries/GetLoginAttemptsQuery.cs
@@ -1,0 +1,42 @@
+namespace Server.Application.Security.Queries;
+
+/// <summary>Returns a most-recent-first page of login attempts.</summary>
+/// <param name="Page">1-based page number.</param>
+/// <param name="PageSize">Rows per page.</param>
+public record GetLoginAttemptsQuery(int? Page, int? PageSize) : IRequest<List<LoginAttemptDto>>;
+
+/// <summary>Returns the total number of recorded login attempts (for pagination headers).</summary>
+public record GetLoginAttemptsCountQuery : IRequest<int>;
+
+/// <summary>Handles <see cref="GetLoginAttemptsQuery"/>.</summary>
+public sealed class GetLoginAttemptsQueryHandler(
+    ILoginAttemptRepository attempts,
+    IMapper mapper,
+    ILogger<GetLoginAttemptsQueryHandler> logger)
+    : IRequestHandler<GetLoginAttemptsQuery, List<LoginAttemptDto>>
+{
+    /// <summary>Loads the requested page of attempts and returns the resulting DTOs.</summary>
+    public async Task<List<LoginAttemptDto>> Handle(GetLoginAttemptsQuery request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(GetLoginAttemptsQuery));
+
+        var pageSize = request.PageSize is > 0 and <= 200 ? request.PageSize.Value : 25;
+        var page = request.Page is > 0 ? request.Page.Value : 1;
+        var items = await attempts.ListAsync(pageSize, (page - 1) * pageSize, cancellationToken);
+        return items.Select(a => mapper.Map<LoginAttemptDto>(a)).ToList();
+    }
+}
+
+/// <summary>Handles <see cref="GetLoginAttemptsCountQuery"/>.</summary>
+public sealed class GetLoginAttemptsCountQueryHandler(
+    ILoginAttemptRepository attempts,
+    ILogger<GetLoginAttemptsCountQueryHandler> logger)
+    : IRequestHandler<GetLoginAttemptsCountQuery, int>
+{
+    /// <summary>Returns the total attempt count.</summary>
+    public async Task<int> Handle(GetLoginAttemptsCountQuery request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(GetLoginAttemptsCountQuery));
+        return await attempts.CountAsync(cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Security/SecurityMappingProfile.cs
+++ b/src/server/Server.Application/Security/SecurityMappingProfile.cs
@@ -1,0 +1,14 @@
+using Server.Domain.Security;
+
+namespace Server.Application.Security;
+
+/// <summary>AutoMapper profile mapping the security entities to their DTOs.</summary>
+public sealed class SecurityMappingProfile : Profile
+{
+    /// <summary>Configures the login-attempt and blacklist mappings (property names line up directly).</summary>
+    public SecurityMappingProfile()
+    {
+        CreateMap<LoginAttempt, LoginAttemptDto>();
+        CreateMap<BlacklistedIp, BlacklistedIpDto>();
+    }
+}

--- a/src/server/Server.Domain/Security/BlacklistedIp.cs
+++ b/src/server/Server.Domain/Security/BlacklistedIp.cs
@@ -1,0 +1,49 @@
+namespace Server.Domain.Security;
+
+/// <summary>
+/// An IP address blocked from signing in — either manually by the user (no expiry) or
+/// automatically after too many failed attempts (temporary, with an expiry).
+/// </summary>
+public sealed class BlacklistedIp : Entity<int>
+{
+    /// <summary>The blocked IP address.</summary>
+    public string IpAddress { get; private set; } = "";
+
+    /// <summary>The username associated with an automatic block (the account being brute-forced), if any.</summary>
+    public string? Username { get; private set; }
+
+    /// <summary>Why the IP was blocked.</summary>
+    public string Reason { get; private set; } = "";
+
+    /// <summary>When the block was created (UTC).</summary>
+    public DateTime CreatedAt { get; private set; }
+
+    /// <summary>When the block lifts (UTC); null means it never expires (a manual block).</summary>
+    public DateTime? ExpiresAt { get; private set; }
+
+    private BlacklistedIp() { }
+
+    /// <summary>A manual, permanent block added by the user.</summary>
+    public static BlacklistedIp Manual(string ipAddress, string? reason) =>
+        new()
+        {
+            IpAddress = ipAddress.Trim(),
+            Reason = string.IsNullOrWhiteSpace(reason) ? "Manually blocked" : reason.Trim(),
+            ExpiresAt = null,
+            CreatedAt = DateTime.UtcNow
+        };
+
+    /// <summary>An automatic, temporary block after repeated failed attempts.</summary>
+    public static BlacklistedIp Temporary(string ipAddress, string? username, string reason, DateTime expiresAt) =>
+        new()
+        {
+            IpAddress = ipAddress.Trim(),
+            Username = string.IsNullOrWhiteSpace(username) ? null : username.Trim(),
+            Reason = reason,
+            ExpiresAt = expiresAt,
+            CreatedAt = DateTime.UtcNow
+        };
+
+    /// <summary>True when this block is still in effect at the given instant.</summary>
+    public bool IsActive(DateTime now) => ExpiresAt is null || ExpiresAt > now;
+}

--- a/src/server/Server.Domain/Security/LoginAttempt.cs
+++ b/src/server/Server.Domain/Security/LoginAttempt.cs
@@ -1,0 +1,40 @@
+namespace Server.Domain.Security;
+
+/// <summary>An immutable audit record of a single sign-in attempt (successful or not).</summary>
+public sealed class LoginAttempt : Entity<int>
+{
+    /// <summary>The username that was tried.</summary>
+    public string Username { get; private set; } = "";
+
+    /// <summary>The client IP the attempt came from (real IP via X-Forwarded-For).</summary>
+    public string IpAddress { get; private set; } = "";
+
+    /// <summary>Whether the attempt succeeded.</summary>
+    public bool Success { get; private set; }
+
+    /// <summary>A short machine-readable outcome, e.g. "success", "invalid_password", "invalid_2fa", "ip_blocked".</summary>
+    public string Reason { get; private set; } = "";
+
+    /// <summary>The requesting user agent, if any (truncated).</summary>
+    public string? UserAgent { get; private set; }
+
+    /// <summary>When the attempt happened (UTC).</summary>
+    public DateTime CreatedAt { get; private set; }
+
+    private LoginAttempt() { }
+
+    /// <summary>Creates an audit record for a sign-in attempt.</summary>
+    public static LoginAttempt Record(string? username, string? ipAddress, bool success, string reason, string? userAgent)
+    {
+        static string Cap(string s, int max) => s.Length > max ? s[..max] : s;
+        return new LoginAttempt
+        {
+            Username = Cap((username ?? "").Trim(), 128),
+            IpAddress = string.IsNullOrWhiteSpace(ipAddress) ? "unknown" : Cap(ipAddress.Trim(), 64),
+            Success = success,
+            Reason = reason ?? "",
+            UserAgent = string.IsNullOrWhiteSpace(userAgent) ? null : Cap(userAgent.Trim(), 256),
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+}

--- a/src/server/Server.Domain/Users/User.cs
+++ b/src/server/Server.Domain/Users/User.cs
@@ -15,6 +15,12 @@ public sealed class User : AggregateRoot<int>
     /// <summary>When the user was created.</summary>
     public DateTime CreatedAt { get; private set; }
 
+    /// <summary>Whether two-factor (TOTP) authentication is active for this user.</summary>
+    public bool TwoFactorEnabled { get; private set; }
+
+    /// <summary>The TOTP shared secret (base32). Present once setup has begun; kept even while disabled only during setup.</summary>
+    public string? TwoFactorSecret { get; private set; }
+
     private User() { }
 
     /// <summary>Creates a new user, requiring a non-empty username.</summary>
@@ -35,4 +41,28 @@ public sealed class User : AggregateRoot<int>
 
     /// <summary>Changes the user's base currency.</summary>
     public void ChangeBaseCurrency(CurrencyCode currency) => BaseCurrency = currency;
+
+    /// <summary>Stores a freshly-generated TOTP secret to begin 2FA setup. 2FA stays disabled until confirmed.</summary>
+    public void BeginTwoFactorSetup(string secret)
+    {
+        if (string.IsNullOrWhiteSpace(secret))
+            throw new DomainException("A two-factor secret is required.");
+        TwoFactorSecret = secret;
+        TwoFactorEnabled = false;
+    }
+
+    /// <summary>Activates 2FA after the user has proven possession of the authenticator (a valid code was verified).</summary>
+    public void ConfirmTwoFactor()
+    {
+        if (string.IsNullOrWhiteSpace(TwoFactorSecret))
+            throw new DomainException("Two-factor setup has not been started.");
+        TwoFactorEnabled = true;
+    }
+
+    /// <summary>Turns 2FA off and discards the secret.</summary>
+    public void DisableTwoFactor()
+    {
+        TwoFactorEnabled = false;
+        TwoFactorSecret = null;
+    }
 }

--- a/src/server/Server.Infrastructure/DependencyInjection.cs
+++ b/src/server/Server.Infrastructure/DependencyInjection.cs
@@ -23,15 +23,19 @@ public static class DependencyInjection
         services.AddScoped<IGoalRepository, GoalRepository>();
         services.AddScoped<ICurrencyRateRepository, CurrencyRateRepository>();
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<ILoginAttemptRepository, LoginAttemptRepository>();
+        services.AddScoped<IBlacklistRepository, BlacklistRepository>();
 
         // Services
         services.AddSingleton<IPasswordHasher, BcryptPasswordHasher>();
         services.AddSingleton<ISystemService, SystemService>();
         services.AddSingleton<IYahooFinanceClient, YahooFinanceClient>();
+        services.AddSingleton<ITotpService, TotpService>();
         services.AddScoped<IPriceService, PriceService>();
         services.AddScoped<IWealthService, WealthService>();
         services.AddScoped<IImporterService, ImporterService>();
         services.AddScoped<IDatabaseBackupService, DatabaseBackupService>();
+        services.AddScoped<ILoginSecurityService, LoginSecurityService>();
 
         return services;
     }

--- a/src/server/Server.Infrastructure/GlobalUsings.cs
+++ b/src/server/Server.Infrastructure/GlobalUsings.cs
@@ -11,3 +11,4 @@ global using Server.Application.Currencies;
 global using Server.Application.Auth;
 global using Server.Application.Prices;
 global using Server.Application.Settings;
+global using Server.Application.Security;

--- a/src/server/Server.Infrastructure/Persistence/CapitrackDbContext.cs
+++ b/src/server/Server.Infrastructure/Persistence/CapitrackDbContext.cs
@@ -2,6 +2,7 @@ using Server.Domain.Accounts;
 using Server.Domain.Categories;
 using Server.Domain.Currencies;
 using Server.Domain.Goals;
+using Server.Domain.Security;
 using Server.Domain.Tags;
 using Server.Domain.Transactions;
 using Server.Domain.Users;
@@ -22,6 +23,8 @@ public class CapitrackDbContext(DbContextOptions<CapitrackDbContext> options) : 
     public DbSet<AccountTag> AccountTags => Set<AccountTag>();
     public DbSet<GoalTag> GoalTags => Set<GoalTag>();
     public DbSet<TransactionTag> TransactionTags => Set<TransactionTag>();
+    public DbSet<LoginAttempt> LoginAttempts => Set<LoginAttempt>();
+    public DbSet<BlacklistedIp> BlacklistedIps => Set<BlacklistedIp>();
 
     protected override void OnModelCreating(ModelBuilder b)
     {
@@ -31,6 +34,7 @@ public class CapitrackDbContext(DbContextOptions<CapitrackDbContext> options) : 
             e.HasIndex(x => x.Username).IsUnique();
             e.Property(x => x.BaseCurrency).HasConversion(v => v.Value, v => CurrencyCode.Create(v));
             e.Property(x => x.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP").ValueGeneratedOnAdd();
+            e.Property(x => x.TwoFactorEnabled).HasDefaultValue(false);
         });
 
         b.Entity<Account>(e =>
@@ -131,6 +135,18 @@ public class CapitrackDbContext(DbContextOptions<CapitrackDbContext> options) : 
             e.HasKey(x => new { x.TransactionId, x.TagId });
             e.HasOne<Transaction>().WithMany().HasForeignKey(x => x.TransactionId).OnDelete(DeleteBehavior.Cascade);
             e.HasOne<Tag>().WithMany().HasForeignKey(x => x.TagId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        b.Entity<LoginAttempt>(e =>
+        {
+            e.HasIndex(x => x.IpAddress);
+            e.HasIndex(x => x.CreatedAt);
+        });
+
+        b.Entity<BlacklistedIp>(e =>
+        {
+            e.HasIndex(x => x.IpAddress);
+            e.HasIndex(x => x.ExpiresAt);
         });
     }
 }

--- a/src/server/Server.Infrastructure/Persistence/Repositories/BlacklistRepository.cs
+++ b/src/server/Server.Infrastructure/Persistence/Repositories/BlacklistRepository.cs
@@ -1,0 +1,39 @@
+using Server.Domain.Security;
+
+namespace Server.Infrastructure.Persistence.Repositories;
+
+/// <summary>EF Core persistence for the IP blacklist.</summary>
+public sealed class BlacklistRepository(CapitrackDbContext db) : IBlacklistRepository
+{
+    /// <inheritdoc />
+    public Task<BlacklistedIp?> GetActiveByIpAsync(string ipAddress, DateTime now, CancellationToken ct = default) =>
+        db.BlacklistedIps
+            .Where(b => b.IpAddress == ipAddress && (b.ExpiresAt == null || b.ExpiresAt > now))
+            .OrderByDescending(b => b.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+    /// <inheritdoc />
+    public Task<BlacklistedIp?> GetManualByIpAsync(string ipAddress, CancellationToken ct = default) =>
+        db.BlacklistedIps.FirstOrDefaultAsync(b => b.IpAddress == ipAddress && b.ExpiresAt == null, ct);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BlacklistedIp>> ListActiveAsync(DateTime now, CancellationToken ct = default) =>
+        await db.BlacklistedIps
+            .Where(b => b.ExpiresAt == null || b.ExpiresAt > now)
+            .OrderByDescending(b => b.CreatedAt)
+            .ToListAsync(ct);
+
+    /// <inheritdoc />
+    public Task<BlacklistedIp?> GetAsync(int id, CancellationToken ct = default) =>
+        db.BlacklistedIps.FirstOrDefaultAsync(b => b.Id == id, ct);
+
+    /// <inheritdoc />
+    public Task AddAsync(BlacklistedIp entry, CancellationToken ct = default)
+    {
+        db.BlacklistedIps.Add(entry);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Remove(BlacklistedIp entry) => db.BlacklistedIps.Remove(entry);
+}

--- a/src/server/Server.Infrastructure/Persistence/Repositories/LoginAttemptRepository.cs
+++ b/src/server/Server.Infrastructure/Persistence/Repositories/LoginAttemptRepository.cs
@@ -1,0 +1,33 @@
+using Server.Domain.Security;
+
+namespace Server.Infrastructure.Persistence.Repositories;
+
+/// <summary>EF Core persistence for <see cref="LoginAttempt"/> audit records.</summary>
+public sealed class LoginAttemptRepository(CapitrackDbContext db) : ILoginAttemptRepository
+{
+    /// <inheritdoc />
+    public Task AddAsync(LoginAttempt attempt, CancellationToken ct = default)
+    {
+        db.LoginAttempts.Add(attempt);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<int> CountRecentFailuresAsync(string ipAddress, DateTime since, CancellationToken ct = default) =>
+        db.LoginAttempts.CountAsync(
+            a => a.IpAddress == ipAddress && !a.Success && a.Reason != "ip_blocked" && a.CreatedAt >= since, ct);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<LoginAttempt>> ListAsync(int limit, int offset, CancellationToken ct = default) =>
+        await db.LoginAttempts
+            .OrderByDescending(a => a.CreatedAt).ThenByDescending(a => a.Id)
+            .Skip(offset).Take(limit)
+            .ToListAsync(ct);
+
+    /// <inheritdoc />
+    public Task<int> CountAsync(CancellationToken ct = default) => db.LoginAttempts.CountAsync(ct);
+
+    /// <inheritdoc />
+    public Task<int> DeleteOlderThanAsync(DateTime cutoff, CancellationToken ct = default) =>
+        db.LoginAttempts.Where(a => a.CreatedAt < cutoff).ExecuteDeleteAsync(ct);
+}

--- a/src/server/Server.Infrastructure/Server.Infrastructure.csproj
+++ b/src/server/Server.Infrastructure/Server.Infrastructure.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="Otp.NET" Version="1.4.0" />
+    <PackageReference Include="QRCoder" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/server/Server.Infrastructure/Services/BcryptPasswordHasher.cs
+++ b/src/server/Server.Infrastructure/Services/BcryptPasswordHasher.cs
@@ -2,6 +2,11 @@ namespace Server.Infrastructure.Services;
 
 public sealed class BcryptPasswordHasher : IPasswordHasher
 {
+    // Computed once at startup with the same work factor as real hashes, so a Verify against it
+    // takes the same time as a real one — used to keep login timing constant when the username
+    // is unknown (mitigates user enumeration via a bcrypt-skip timing oracle).
+    public string DummyHash { get; } = BCrypt.Net.BCrypt.HashPassword(Guid.NewGuid().ToString(), 12);
+
     public string Hash(string password) => BCrypt.Net.BCrypt.HashPassword(password, 12);
 
     public bool Verify(string password, string hash)

--- a/src/server/Server.Infrastructure/Services/LoginSecurityService.cs
+++ b/src/server/Server.Infrastructure/Services/LoginSecurityService.cs
@@ -1,0 +1,45 @@
+using Server.Domain.Security;
+
+namespace Server.Infrastructure.Services;
+
+/// <summary>
+/// Brute-force protection shared by both login steps: 3 genuine failures from an IP within a
+/// 15-minute window trigger a 15-minute IP block. Every attempt is audited.
+/// </summary>
+public sealed class LoginSecurityService(
+    ILoginAttemptRepository attempts,
+    IBlacklistRepository blacklist,
+    IUnitOfWork uow) : ILoginSecurityService
+{
+    private const int MaxFailures = 3;
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan BlockDuration = TimeSpan.FromMinutes(15);
+
+    /// <inheritdoc />
+    public async Task<bool> IsIpBlockedAsync(string ipAddress, CancellationToken ct = default) =>
+        await blacklist.GetActiveByIpAsync(ipAddress, DateTime.UtcNow, ct) is not null;
+
+    /// <inheritdoc />
+    public async Task RecordAttemptAsync(string? username, string ipAddress, bool success, string reason, string? userAgent, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        await attempts.AddAsync(LoginAttempt.Record(username, ipAddress, success, reason, userAgent), ct);
+        await uow.SaveChangesAsync(ct);
+
+        // Only genuine credential/2FA failures escalate to a block — never the "ip_blocked" rejections
+        // themselves (otherwise a block could perpetually renew itself).
+        if (success || reason == "ip_blocked") return;
+
+        var failures = await attempts.CountRecentFailuresAsync(ipAddress, now - Window, ct);
+        if (failures < MaxFailures) return;
+
+        // Don't stack blocks — only add one if the IP isn't already actively blocked.
+        if (await blacklist.GetActiveByIpAsync(ipAddress, now, ct) is not null) return;
+
+        await blacklist.AddAsync(
+            BlacklistedIp.Temporary(ipAddress, username,
+                $"Auto-blocked after {failures} failed sign-in attempts", now + BlockDuration),
+            ct);
+        await uow.SaveChangesAsync(ct);
+    }
+}

--- a/src/server/Server.Infrastructure/Services/TotpService.cs
+++ b/src/server/Server.Infrastructure/Services/TotpService.cs
@@ -1,0 +1,52 @@
+using OtpNet;
+using QRCoder;
+
+namespace Server.Infrastructure.Services;
+
+/// <summary>
+/// TOTP (RFC 6238) two-factor implementation via Otp.NET, with the QR rendered by QRCoder as
+/// a dependency-free SVG. Codes are 6 digits over a 30-second step; verification allows a ±1
+/// step of clock skew (the current step plus the adjacent ones, a ~90-second acceptance span).
+/// The brute-force IP block, not a narrow window, is what bounds guessing.
+/// </summary>
+public sealed class TotpService : ITotpService
+{
+    /// <inheritdoc />
+    public string GenerateSecret() => Base32Encoding.ToString(KeyGeneration.GenerateRandomKey(20));
+
+    /// <inheritdoc />
+    public string BuildOtpAuthUri(string secret, string account, string issuer)
+    {
+        var label = Uri.EscapeDataString($"{issuer}:{account}");
+        var iss = Uri.EscapeDataString(issuer);
+        var sec = Uri.EscapeDataString(secret);
+        return $"otpauth://totp/{label}?secret={sec}&issuer={iss}&algorithm=SHA1&digits=6&period=30";
+    }
+
+    /// <inheritdoc />
+    public string GenerateQrSvg(string otpauthUri)
+    {
+        using var generator = new QRCodeGenerator();
+        using var data = generator.CreateQrCode(otpauthUri, QRCodeGenerator.ECCLevel.M);
+        return new SvgQRCode(data).GetGraphic(4);
+    }
+
+    /// <inheritdoc />
+    public bool VerifyCode(string? secret, string? code)
+    {
+        if (string.IsNullOrWhiteSpace(secret) || string.IsNullOrWhiteSpace(code)) return false;
+
+        var trimmed = code.Trim();
+        if (trimmed.Length != 6 || !trimmed.All(char.IsDigit)) return false;
+
+        try
+        {
+            var totp = new Totp(Base32Encoding.ToBytes(secret));
+            return totp.VerifyTotp(trimmed, out _, new VerificationWindow(previous: 1, future: 1));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/Server.Tests/SecurityTests.cs
+++ b/tests/Server.Tests/SecurityTests.cs
@@ -1,0 +1,94 @@
+using Server.Domain.Security;
+using Server.Domain.Users;
+
+namespace Server.Tests;
+
+public class SecurityTests
+{
+    // ---- User: two-factor lifecycle ----
+
+    [Fact]
+    public void Begin_two_factor_setup_stores_secret_but_leaves_it_disabled()
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        user.BeginTwoFactorSetup("JBSWY3DPEHPK3PXP");
+        user.TwoFactorSecret.Should().Be("JBSWY3DPEHPK3PXP");
+        user.TwoFactorEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Begin_two_factor_setup_rejects_an_empty_secret()
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        var act = () => user.BeginTwoFactorSetup("  ");
+        act.Should().Throw<DomainException>();
+    }
+
+    [Fact]
+    public void Confirm_two_factor_requires_setup_to_have_started()
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        var act = user.ConfirmTwoFactor;
+        act.Should().Throw<DomainException>();
+    }
+
+    [Fact]
+    public void Confirm_two_factor_enables_after_setup()
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        user.BeginTwoFactorSetup("JBSWY3DPEHPK3PXP");
+        user.ConfirmTwoFactor();
+        user.TwoFactorEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Disable_two_factor_clears_the_flag_and_secret()
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        user.BeginTwoFactorSetup("JBSWY3DPEHPK3PXP");
+        user.ConfirmTwoFactor();
+
+        user.DisableTwoFactor();
+
+        user.TwoFactorEnabled.Should().BeFalse();
+        user.TwoFactorSecret.Should().BeNull();
+    }
+
+    // ---- LoginAttempt audit record ----
+
+    [Fact]
+    public void Login_attempt_defaults_a_blank_ip_to_unknown()
+    {
+        var attempt = LoginAttempt.Record("admin", "  ", success: false, "invalid_password", userAgent: null);
+        attempt.IpAddress.Should().Be("unknown");
+        attempt.UserAgent.Should().BeNull();
+        attempt.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Login_attempt_caps_an_overlong_username()
+    {
+        var attempt = LoginAttempt.Record(new string('x', 500), "1.2.3.4", success: true, "success", "agent");
+        attempt.Username.Length.Should().Be(128);
+    }
+
+    // ---- BlacklistedIp ----
+
+    [Fact]
+    public void Manual_block_never_expires()
+    {
+        var block = BlacklistedIp.Manual("203.0.113.7", "spam");
+        block.ExpiresAt.Should().BeNull();
+        block.IsActive(DateTime.UtcNow.AddYears(10)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Temporary_block_is_active_until_it_expires()
+    {
+        var now = DateTime.UtcNow;
+        var block = BlacklistedIp.Temporary("203.0.113.7", "admin", "brute force", now.AddMinutes(15));
+        block.IsActive(now.AddMinutes(5)).Should().BeTrue();
+        block.IsActive(now.AddMinutes(20)).Should().BeFalse();
+        block.Username.Should().Be("admin");
+    }
+}


### PR DESCRIPTION
## What

Adds the requested dashboard security features, plus hardening surfaced by an adversarial security review.

### 2FA (TOTP, RFC 6238)
- **Settings → Security** can enable 2FA: scan a server-rendered QR (QRCoder SVG), confirm a 6-digit code, and 2FA becomes **required at login**.
- Login becomes **two-step** when enabled: password first returns `two_factor_required` (no cookie is set), then the code completes sign-in.
- Setup is **idempotent** — repeated `/2fa/setup` reuses the pending secret so a scanned QR can't be invalidated, and never silently disables an active 2FA.

### Login Security section
- **Audit log** of every sign-in attempt — username, real client IP, outcome, user agent — paged via `X-Total-Count`.
- **IP blacklist** the user can add to / remove from. Only publicly-routable IPs may be blocked (private / loopback / link-local are rejected so the reverse proxy or admin range can't be locked out).
- **Brute-force lockout**: 3 genuine failures from an IP within 15 minutes auto-block that IP for 15 minutes (`429`). Wrong 2FA codes and authenticated confirm/disable failures count toward it too.

## Adversarial review → fixes

A workflow ran 5 attack-lens finders (auth-bypass, TOTP, brute-force, IP-spoofing, info-leak), each finding independently verified. 10 issues confirmed; **9 fixed**, 1 accepted:

| Sev | Finding | Fix |
|-----|---------|-----|
| high | bcrypt skipped for unknown user → user-enumeration timing oracle | Constant-time verify against a dummy hash |
| high | `/2fa/confirm` unthrottled code brute-force | Rate-limited by the shared IP block |
| high | `/2fa/disable` unthrottled password brute-force (stolen cookie strips 2FA) | Rate-limited by the shared IP block |
| high | `/2fa/setup` overwrote a pending secret each call | Idempotent — reuse pending secret |
| high | Any IP (incl. proxy/admin) could be blacklisted → self-DoS | Reject non-public IPs |
| high | `LoginAttempts` grew unbounded → disk DoS | Stop logging blocked hits + 90-day retention job |
| high | `X-Forwarded-For` trusted from all proxies (spoofable if API port exposed) | Trust only private-network proxies |
| med | `/login/2fa` signed in without a code when 2FA disabled | Reject non-2FA accounts |
| low | TOTP window comment said ~30s but was ~90s | Corrected comment |
| med | Race → duplicate auto-block rows under concurrency | **Accepted** — SQLite serializes writes; only cosmetic duplicate rows, the IP stays blocked; retention prunes. No clean `EnsureCreated`-compatible DB fix. |

## Tests
- **Server.Tests 63/63** (+9: 2FA lifecycle, audit record, blacklist expiry), **Client.Tests 14/14**.
- Full solution build green (only pre-existing Fluxor `NU1608` + transitive SQLite `NU1903` warnings).
- **Runtime-verified end-to-end** against the composed stack: no-2FA login, two-step 2FA login, idempotent setup, non-2FA `/login/2fa` → 401, user-enumeration parity, non-public-IP rejection, disable-throttle → 429, and blocked hits not logged.

## Notes
- New tables/columns (`LoginAttempts`, `BlacklistedIps`, `users.two_factor_*`) appear on a fresh DB — the app uses `EnsureCreated`, not EF migrations.
- The IP is always taken server-side (`RemoteIpAddress` via forwarded headers), never from the request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
