### PR TITLE
feat(security): configurable session lifetime (15 min – 2 h)

### DIFF
--- a/src/client/Client.Application/Models/SessionDto.cs
+++ b/src/client/Client.Application/Models/SessionDto.cs
@@ -1,9 +1,10 @@
 namespace Client.Application.Models;
 
-/// <summary>The authenticated user's session info (username, base currency and 2FA state).</summary>
+/// <summary>The authenticated user's session info (username, base currency, 2FA state and session lifetime).</summary>
 public class SessionDto
 {
     public string Username { get; set; } = "";
     public string BaseCurrency { get; set; } = "EUR";
     public bool TwoFactorEnabled { get; set; }
+    public int SessionLifetimeMinutes { get; set; } = 120;
 }

--- a/src/client/Client.Presentation/Pages/Settings.razor
+++ b/src/client/Client.Presentation/Pages/Settings.razor
@@ -238,6 +238,25 @@
 
                     <div style="height:1px;background:var(--border);margin:24px 0;"></div>
 
+                    <div style="font-weight:600;font-size:0.92rem;margin-bottom:4px;">Session</div>
+                    <p class="sub" style="margin-bottom:14px;line-height:1.6;">How long you stay signed in without activity. Applies immediately, including to the current session.</p>
+                    <div class="flex gap-2" style="align-items:flex-end;">
+                        <div class="field" style="margin-bottom:0;">
+                            <label>Session lifetime</label>
+                            <select class="input" style="width:200px;" @bind="_sessionLifetime">
+                                <option value="15">15 minutes</option>
+                                <option value="30">30 minutes</option>
+                                <option value="45">45 minutes</option>
+                                <option value="60">1 hour</option>
+                                <option value="90">1.5 hours</option>
+                                <option value="120">2 hours</option>
+                            </select>
+                        </div>
+                        <button class="btn btn-pri btn-sm" @onclick="SaveSessionLifetime"><Icon Name="check" /> Save</button>
+                    </div>
+
+                    <div style="height:1px;background:var(--border);margin:24px 0;"></div>
+
                     <div style="font-weight:600;font-size:0.92rem;margin-bottom:4px;">Two-factor authentication</div>
                     <p class="sub" style="margin-bottom:14px;line-height:1.6;">Require a 6-digit code from an authenticator app in addition to your password when signing in.</p>
 
@@ -493,6 +512,7 @@
 
     // ---- Two-factor auth ----
     private bool _twoFactorEnabled;
+    private int _sessionLifetime = 120;
     private TwoFactorSetupDto? _setup;
     private string _setupCode = "";
     private string? _setupMsg;
@@ -521,6 +541,7 @@
         var session = await Api.GetAsync<SessionDto>("/api/auth/session");
         _base = session?.BaseCurrency ?? "EUR";
         _twoFactorEnabled = session?.TwoFactorEnabled ?? false;
+        _sessionLifetime = session?.SessionLifetimeMinutes ?? 120;
         var about = await Api.GetAsync<AboutDto>("/api/settings/about");
         _version = about?.Version ?? "1.0.0";
         var db = await Api.GetAsync<DatabaseInfoDto>("/api/settings/database");
@@ -683,6 +704,14 @@
     }
 
     private async Task ToggleDots() => await Prefs.SetShowTransactionDots(!Prefs.ShowTransactionDots);
+
+    private async Task SaveSessionLifetime()
+    {
+        var (ok, _) = await Api.PutWithStatusAsync<JsonElement>("/api/auth/session-lifetime", new { minutes = _sessionLifetime });
+        Toast.Show(ok
+            ? $"Sessions now expire after {(_sessionLifetime >= 60 ? $"{_sessionLifetime / 60.0:0.#} hour(s)" : $"{_sessionLifetime} minutes")} of inactivity"
+            : "Could not update session lifetime", ok ? "success" : "error");
+    }
 
     // ---- Security ----
     private async Task ChangePassword()

--- a/src/server/Server.Api/Controllers/AuthController.cs
+++ b/src/server/Server.Api/Controllers/AuthController.cs
@@ -58,6 +58,15 @@ public sealed class AuthController(IMediator mediator) : ControllerBase
         return Ok(new { message = "Base currency updated" });
     }
 
+    /// <summary>Changes how long sessions stay signed in (15–120 minutes). Applies to live sessions too.</summary>
+    [HttpPut("session-lifetime")]
+    [Authorize]
+    public async Task<IActionResult> ChangeSessionLifetime([FromBody] ChangeSessionLifetimeCommand command)
+    {
+        await mediator.Send(command);
+        return Ok(new { message = "Session lifetime updated" });
+    }
+
     /// <summary>Begins 2FA setup: returns the secret, otpauth URI and a QR SVG to scan.</summary>
     [HttpPost("2fa/setup")]
     [Authorize]
@@ -86,7 +95,19 @@ public sealed class AuthController(IMediator mediator) : ControllerBase
         var identity = new ClaimsIdentity(
             [new Claim(ClaimTypes.Name, session.Username)],
             CookieAuthenticationDefaults.AuthenticationScheme);
-        await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
+        // The ticket carries the user's configured lifetime; sliding expiration renews it in
+        // same-sized windows, so this acts as an inactivity timeout of exactly that length.
+        var now = DateTimeOffset.UtcNow;
+        await HttpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            new ClaimsPrincipal(identity),
+            new AuthenticationProperties
+            {
+                IsPersistent = true,
+                AllowRefresh = true,
+                IssuedUtc = now,
+                ExpiresUtc = now.AddMinutes(session.SessionLifetimeMinutes)
+            });
     }
 
     private string ClientIp() => HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";

--- a/src/server/Server.Api/Program.cs
+++ b/src/server/Server.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -47,10 +48,43 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         o.Cookie.HttpOnly = true;
         o.Cookie.SameSite = SameSiteMode.Strict;
         o.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
-        o.ExpireTimeSpan = TimeSpan.FromDays(7);
+        // Fallback only — each sign-in stamps the ticket with the user's configured lifetime
+        // (15–120 min), and OnValidatePrincipal below re-applies it when the setting changes.
+        o.ExpireTimeSpan = TimeSpan.FromMinutes(Server.Domain.Users.User.MaxSessionLifetimeMinutes);
         o.SlidingExpiration = true;
         o.Events.OnRedirectToLogin = ctx => { ctx.Response.StatusCode = 401; return Task.CompletedTask; };
         o.Events.OnRedirectToAccessDenied = ctx => { ctx.Response.StatusCode = 403; return Task.CompletedTask; };
+        // Enforce the CURRENT configured session lifetime on every request, so changing the
+        // setting also applies to cookies issued earlier (shorter → sessions past the new
+        // limit are rejected; different → the ticket window is rewritten and the cookie renewed).
+        o.Events.OnValidatePrincipal = async ctx =>
+        {
+            var username = ctx.Principal?.Identity?.Name;
+            if (string.IsNullOrEmpty(username) || ctx.Properties.IssuedUtc is not { } issued) return;
+
+            var users = ctx.HttpContext.RequestServices.GetRequiredService<IUserRepository>();
+            var user = await users.GetByUsernameAsync(username, ctx.HttpContext.RequestAborted);
+            if (user is null)
+            {
+                ctx.RejectPrincipal();
+                await ctx.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                return;
+            }
+
+            var lifetime = TimeSpan.FromMinutes(user.SessionLifetimeMinutes);
+            if (DateTimeOffset.UtcNow > issued + lifetime)
+            {
+                ctx.RejectPrincipal();
+                await ctx.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                return;
+            }
+
+            if (ctx.Properties.ExpiresUtc - issued != lifetime)
+            {
+                ctx.Properties.ExpiresUtc = issued + lifetime;
+                ctx.ShouldRenew = true;
+            }
+        };
     });
 builder.Services.AddAuthorization();
 

--- a/src/server/Server.Application/Auth/Commands/ChangeSessionLifetimeCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/ChangeSessionLifetimeCommand.cs
@@ -1,0 +1,42 @@
+using Server.Application.Common.Exceptions;
+using Server.Domain.Users;
+
+namespace Server.Application.Auth.Commands;
+
+/// <summary>Changes how long a signed-in session stays valid without activity.</summary>
+/// <param name="Minutes">The new lifetime in minutes (15–120).</param>
+public record ChangeSessionLifetimeCommand(int? Minutes) : IRequest;
+
+/// <summary>Validates <see cref="ChangeSessionLifetimeCommand"/>.</summary>
+public sealed class ChangeSessionLifetimeValidator : AbstractValidator<ChangeSessionLifetimeCommand>
+{
+    /// <summary>Requires a lifetime within the allowed 15-minute to 2-hour range.</summary>
+    public ChangeSessionLifetimeValidator() =>
+        RuleFor(x => x.Minutes)
+            .NotNull().WithMessage("A session lifetime is required.")
+            .InclusiveBetween(User.MinSessionLifetimeMinutes, User.MaxSessionLifetimeMinutes)
+            .WithMessage($"Session lifetime must be between {User.MinSessionLifetimeMinutes} minutes and {User.MaxSessionLifetimeMinutes / 60} hours.");
+}
+
+/// <summary>Handles <see cref="ChangeSessionLifetimeCommand"/>.</summary>
+public sealed class ChangeSessionLifetimeHandler(
+    ICurrentUser currentUser,
+    IUserRepository users,
+    IUnitOfWork uow,
+    ILogger<ChangeSessionLifetimeHandler> logger)
+    : IRequestHandler<ChangeSessionLifetimeCommand>
+{
+    /// <summary>Persists the new lifetime; the cookie middleware picks it up on the next request.</summary>
+    public async Task Handle(ChangeSessionLifetimeCommand request, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling {Request}", nameof(ChangeSessionLifetimeCommand));
+
+        if (!currentUser.IsAuthenticated)
+            throw new UnauthorizedException("Not authenticated");
+        var user = await users.GetByUsernameAsync(currentUser.Username!, cancellationToken)
+                   ?? throw new UnauthorizedException("Not authenticated");
+
+        user.ChangeSessionLifetime(request.Minutes!.Value);
+        await uow.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/server/Server.Application/Auth/Commands/LoginCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/LoginCommand.cs
@@ -45,6 +45,6 @@ public sealed class LoginHandler(
             return LoginResultDto.Requires2Fa();
 
         await security.RecordAttemptAsync(user.Username, ip, true, "success", request.UserAgent, cancellationToken);
-        return LoginResultDto.SignedIn(new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled));
+        return LoginResultDto.SignedIn(new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled, user.SessionLifetimeMinutes));
     }
 }

--- a/src/server/Server.Application/Auth/Commands/VerifyTwoFactorLoginCommand.cs
+++ b/src/server/Server.Application/Auth/Commands/VerifyTwoFactorLoginCommand.cs
@@ -52,6 +52,6 @@ public sealed class VerifyTwoFactorLoginHandler(
         }
 
         await security.RecordAttemptAsync(user.Username, ip, true, "success", request.UserAgent, cancellationToken);
-        return LoginResultDto.SignedIn(new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled));
+        return LoginResultDto.SignedIn(new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled, user.SessionLifetimeMinutes));
     }
 }

--- a/src/server/Server.Application/Auth/Queries/GetSessionQuery.cs
+++ b/src/server/Server.Application/Auth/Queries/GetSessionQuery.cs
@@ -23,6 +23,6 @@ public sealed class GetSessionQueryHandler(
         var user = await users.GetByUsernameAsync(currentUser.Username!, cancellationToken)
                    ?? throw new UnauthorizedException("Not authenticated");
 
-        return new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled);
+        return new SessionDto(user.Username, user.BaseCurrency.Value, user.TwoFactorEnabled, user.SessionLifetimeMinutes);
     }
 }

--- a/src/server/Server.Application/Auth/SessionDto.cs
+++ b/src/server/Server.Application/Auth/SessionDto.cs
@@ -4,4 +4,5 @@ namespace Server.Application.Auth;
 /// <param name="Username">The signed-in user's name.</param>
 /// <param name="BaseCurrency">The user's base currency code.</param>
 /// <param name="TwoFactorEnabled">Whether two-factor authentication is active for the user.</param>
-public record SessionDto(string Username, string BaseCurrency, bool TwoFactorEnabled);
+/// <param name="SessionLifetimeMinutes">How long the session stays valid without activity, in minutes.</param>
+public record SessionDto(string Username, string BaseCurrency, bool TwoFactorEnabled, int SessionLifetimeMinutes);

--- a/src/server/Server.Domain/Users/User.cs
+++ b/src/server/Server.Domain/Users/User.cs
@@ -21,6 +21,15 @@ public sealed class User : AggregateRoot<int>
     /// <summary>The TOTP shared secret (base32). Present once setup has begun; kept even while disabled only during setup.</summary>
     public string? TwoFactorSecret { get; private set; }
 
+    /// <summary>The shortest session lifetime a user may configure.</summary>
+    public const int MinSessionLifetimeMinutes = 15;
+
+    /// <summary>The longest session lifetime a user may configure (also the default).</summary>
+    public const int MaxSessionLifetimeMinutes = 120;
+
+    /// <summary>How long a signed-in session stays valid without activity, in minutes (15–120).</summary>
+    public int SessionLifetimeMinutes { get; private set; } = MaxSessionLifetimeMinutes;
+
     private User() { }
 
     /// <summary>Creates a new user, requiring a non-empty username.</summary>
@@ -64,5 +73,14 @@ public sealed class User : AggregateRoot<int>
     {
         TwoFactorEnabled = false;
         TwoFactorSecret = null;
+    }
+
+    /// <summary>Changes how long sessions stay valid, bounded to 15 minutes – 2 hours.</summary>
+    public void ChangeSessionLifetime(int minutes)
+    {
+        if (minutes is < MinSessionLifetimeMinutes or > MaxSessionLifetimeMinutes)
+            throw new DomainException(
+                $"Session lifetime must be between {MinSessionLifetimeMinutes} and {MaxSessionLifetimeMinutes} minutes.");
+        SessionLifetimeMinutes = minutes;
     }
 }

--- a/src/server/Server.Infrastructure/DependencyInjection.cs
+++ b/src/server/Server.Infrastructure/DependencyInjection.cs
@@ -45,6 +45,12 @@ public static class DependencyInjection
         using var scope = provider.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<CapitrackDbContext>();
         db.Database.EnsureCreated();
+        // EnsureCreated is a no-op on an existing database, so upgrade its schema to the
+        // current model (adds tables/columns introduced since the volume was created).
+        var logger = scope.ServiceProvider
+            .GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>()
+            .CreateLogger(nameof(SqliteSchemaUpgrader));
+        SqliteSchemaUpgrader.Upgrade(db, logger);
         var hasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
         SeedService.Seed(db, hasher);
     }

--- a/src/server/Server.Infrastructure/Persistence/CapitrackDbContext.cs
+++ b/src/server/Server.Infrastructure/Persistence/CapitrackDbContext.cs
@@ -35,6 +35,7 @@ public class CapitrackDbContext(DbContextOptions<CapitrackDbContext> options) : 
             e.Property(x => x.BaseCurrency).HasConversion(v => v.Value, v => CurrencyCode.Create(v));
             e.Property(x => x.CreatedAt).HasDefaultValueSql("CURRENT_TIMESTAMP").ValueGeneratedOnAdd();
             e.Property(x => x.TwoFactorEnabled).HasDefaultValue(false);
+            e.Property(x => x.SessionLifetimeMinutes).HasDefaultValue(User.MaxSessionLifetimeMinutes);
         });
 
         b.Entity<Account>(e =>

--- a/src/server/Server.Infrastructure/Persistence/SqliteSchemaUpgrader.cs
+++ b/src/server/Server.Infrastructure/Persistence/SqliteSchemaUpgrader.cs
@@ -1,0 +1,110 @@
+using System.Data;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Logging;
+
+namespace Server.Infrastructure.Persistence;
+
+/// <summary>
+/// Brings an EXISTING SQLite database up to the current EF model. <c>EnsureCreated</c> only
+/// builds schema on a brand-new database — it never alters one that already has tables — so
+/// without this step any entity or column added in a release would break deployments that
+/// keep their data volume. The upgrade is model-driven (nothing hard-coded): it diffs the
+/// live schema against the EF model, creates missing tables (with their indexes) from EF's
+/// own create script, and ADDs missing columns with their mapped type/nullability/default.
+/// Destructive changes (drops, renames, type changes) are intentionally out of scope.
+/// </summary>
+public static class SqliteSchemaUpgrader
+{
+    /// <summary>Applies any missing tables/columns. Idempotent; a fresh database is a no-op.</summary>
+    public static void Upgrade(CapitrackDbContext db, ILogger? logger = null)
+    {
+        var existingTables = QuerySingleColumn(db, "SELECT name FROM sqlite_master WHERE type = 'table'")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (existingTables.Count == 0) return; // fresh database — EnsureCreated built everything
+
+        CreateMissingTables(db, existingTables, logger);
+        AddMissingColumns(db, existingTables, logger);
+    }
+
+    /// <summary>Executes the statements of EF's create script that target tables not yet in the database.</summary>
+    private static void CreateMissingTables(CapitrackDbContext db, HashSet<string> existingTables, ILogger? logger)
+    {
+        // Each DDL statement ends with ';' at end-of-line; the bodies contain no semicolons.
+        var statements = Regex.Split(db.Database.GenerateCreateScript(), @";\s*(?:\r?\n|$)")
+            .Select(s => s.Trim()).Where(s => s.Length > 0);
+
+        foreach (var sql in statements)
+        {
+            var table =
+                Regex.Match(sql, "^CREATE TABLE \"([^\"]+)\"", RegexOptions.IgnoreCase) is { Success: true } t ? t.Groups[1].Value :
+                Regex.Match(sql, " ON \"([^\"]+)\"", RegexOptions.IgnoreCase) is { Success: true } i ? i.Groups[1].Value : null;
+            if (table is null || existingTables.Contains(table)) continue;
+
+            logger?.LogInformation("Schema upgrade: creating missing object for table {Table}", table);
+            db.Database.ExecuteSqlRaw(sql);
+        }
+    }
+
+    /// <summary>ALTERs existing tables to add any column present in the model but absent in the database.</summary>
+    private static void AddMissingColumns(CapitrackDbContext db, HashSet<string> existingTables, ILogger? logger)
+    {
+        foreach (var entity in db.Model.GetEntityTypes())
+        {
+            var table = entity.GetTableName();
+            if (table is null || !existingTables.Contains(table)) continue;
+
+            var store = StoreObjectIdentifier.Table(table, entity.GetSchema());
+            var existingColumns = QuerySingleColumn(db, $"SELECT name FROM pragma_table_info('{table}')")
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var property in entity.GetProperties())
+            {
+                var column = property.GetColumnName(store);
+                if (column is null || existingColumns.Contains(column)) continue;
+
+                var ddl = $"ALTER TABLE \"{table}\" ADD COLUMN \"{column}\" {property.GetColumnType()}";
+                if (!property.IsColumnNullable(store))
+                    ddl += $" NOT NULL DEFAULT {DefaultLiteral(property, store)}";
+
+                logger?.LogInformation("Schema upgrade: {Ddl}", ddl);
+                db.Database.ExecuteSqlRaw(ddl);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A constant DEFAULT for the ADD COLUMN (SQLite forbids non-constant defaults there, so
+    /// expressions like CURRENT_TIMESTAMP fall back to a type-appropriate zero value).
+    /// </summary>
+    private static string DefaultLiteral(IProperty property, StoreObjectIdentifier store)
+    {
+        var sql = property.GetDefaultValueSql(store);
+        if (sql is not null && !sql.Contains('(') && !sql.Contains("CURRENT", StringComparison.OrdinalIgnoreCase))
+            return sql;
+
+        if (property.TryGetDefaultValue(store, out var value) && value is not null)
+            return value switch
+            {
+                bool b => b ? "1" : "0",
+                string s => $"'{s.Replace("'", "''")}'",
+                DateTime dt => $"'{dt:yyyy-MM-dd HH:mm:ss}'",
+                _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "0"
+            };
+
+        return property.GetColumnType().Contains("TEXT", StringComparison.OrdinalIgnoreCase) ? "''" : "0";
+    }
+
+    private static List<string> QuerySingleColumn(CapitrackDbContext db, string sql)
+    {
+        var connection = db.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open) connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        var values = new List<string>();
+        while (reader.Read()) values.Add(reader.GetString(0));
+        return values;
+    }
+}

--- a/tests/Server.Tests/SecurityTests.cs
+++ b/tests/Server.Tests/SecurityTests.cs
@@ -54,6 +54,39 @@ public class SecurityTests
         user.TwoFactorSecret.Should().BeNull();
     }
 
+    // ---- Session lifetime ----
+
+    [Fact]
+    public void Session_lifetime_defaults_to_two_hours()
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        user.SessionLifetimeMinutes.Should().Be(120);
+    }
+
+    [Theory]
+    [InlineData(15)]
+    [InlineData(60)]
+    [InlineData(120)]
+    public void Session_lifetime_accepts_values_within_range(int minutes)
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        user.ChangeSessionLifetime(minutes);
+        user.SessionLifetimeMinutes.Should().Be(minutes);
+    }
+
+    [Theory]
+    [InlineData(14)]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(121)]
+    [InlineData(1440)]
+    public void Session_lifetime_rejects_values_outside_range(int minutes)
+    {
+        var user = User.Create("admin", "hash", CurrencyCode.Eur);
+        var act = () => user.ChangeSessionLifetime(minutes);
+        act.Should().Throw<DomainException>();
+    }
+
     // ---- LoginAttempt audit record ----
 
     [Fact]


### PR DESCRIPTION
## What

**Settings → Security** gains a **Session** section where you choose how long a signed-in session stays valid without activity: 15 / 30 / 45 minutes, 1 / 1.5 / 2 hours (default **2 h**, replacing the previous fixed 7-day cookie).

## How it works

- The lifetime lives on the `User` aggregate (`SessionLifetimeMinutes`, domain-validated 15–120) and is exposed in the session DTO (`session_lifetime_minutes`), settable via `PUT /api/auth/session-lifetime`.
- At sign-in the auth ticket is stamped with the configured lifetime; **sliding expiration** renews it in same-sized windows, so it acts as an inactivity timeout of exactly that length.
- `OnValidatePrincipal` re-applies the **current** setting on every request, so changes affect live sessions too: shortening it rejects sessions already past the new limit; any change rewrites the ticket window and reissues the cookie.

## Schema upgrades without a wipe (new)

The app builds schema with `EnsureCreated`, which is a **no-op on an existing database** — until now, any new column/table required a fresh volume. This PR adds a model-driven **`SqliteSchemaUpgrader`** that runs at startup: it diffs the live SQLite schema against the EF model, creates missing tables (with their indexes) from EF's own create script, and `ALTER TABLE … ADD COLUMN`s missing columns with their mapped type/nullability/default. Nothing is hard-coded and destructive changes are out of scope. Deployments upgrading from any earlier image now keep their data.

## Verification (against an existing DB with real data)

- Startup log: `Schema upgrade: ALTER TABLE "Users" ADD COLUMN "SessionLifetimeMinutes" INTEGER NOT NULL DEFAULT 120` — login works, all accounts intact.
- Default 120 → cookie expires in ~120 min; set 15 → fresh login cookie expires in exactly 15 min.
- Changing back to 120 **mid-session** renewed the live cookie to 120 min on the next request.
- Guards: `minutes: 10` → 400, `121` → 400, unauthenticated → 401.
- UI verified in the browser: Session section renders with the select initialized from the API.
- Tests: Server **72/72** (+9 domain tests for bounds/default), Client **14/14**. E2E suite intentionally skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
